### PR TITLE
Prevents zooming in the rendered html

### DIFF
--- a/Resources/DownView.bundle/index.html
+++ b/Resources/DownView.bundle/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=640"/>
+    <meta name="viewport" content="width=640, user-scalable=no"/>
     <link charset="utf-8" href="css/down.min.css" rel="stylesheet">
     <script charset="utf-8" src="js/highlight.min.js" type="text/javascript"></script>
     <script charset="utf-8" src="js/down.js" type="text/javascript"></script>


### PR DESCRIPTION
Addresses issue #16

I came across the need to disable zoom in my `DownView`. I thought of two solutions:
1) Disable zoom per default
2) Inject a flag when initializing the `DownView` which enables/disables zoom

This pull request implements option 1) since I imagine this being the most common 