### PR TITLE
Add optional stylesheet argument for NSAttributedString renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ let commonMark = try? down.toCommonMark()
 
 // Convert to an attributed string
 let attributedString = try? down.toAttributedString()
-// NSAttributedString representation of the rendered HTML
+// NSAttributedString representation of the rendered HTML;
+// by default, uses a stylesheet that matches NSAttributedString's default font,
+// but you can override this by passing in your own, using the 'stylesheet:' parameter.
 
 // Convert to abstract syntax tree
 let ast = try? down.toAST()

--- a/Source/Renderers/DownAttributedStringRenderable.swift
+++ b/Source/Renderers/DownAttributedStringRenderable.swift
@@ -15,6 +15,8 @@ public protocol DownAttributedStringRenderable: DownHTMLRenderable {
 
      - parameter options: `DownOptions` to modify parsing or rendering
 
+     - parameter stylesheet: a `String` to use as a CSS stylesheet when rendering
+
      - throws: `DownErrors` depending on the scenario
 
      - returns: An `NSAttributedString`
@@ -28,6 +30,8 @@ public extension DownAttributedStringRenderable {
      Generates an `NSAttributedString` from the `markdownString` property
 
      - parameter options: `DownOptions` to modify parsing or rendering, defaulting to `.default`
+
+     - parameter stylesheet: a `String` to use as the CSS stylesheet when rendering, defaulting to a style that uses the `NSAttributedString` default font
 
      - throws: `DownErrors` depending on the scenario
 

--- a/Source/Renderers/DownAttributedStringRenderable.swift
+++ b/Source/Renderers/DownAttributedStringRenderable.swift
@@ -20,7 +20,7 @@ public protocol DownAttributedStringRenderable: DownHTMLRenderable {
      - returns: An `NSAttributedString`
      */
     
-    func toAttributedString(_ options: DownOptions) throws -> NSAttributedString
+    func toAttributedString(_ options: DownOptions, stylesheet: String?) throws -> NSAttributedString
 }
 
 public extension DownAttributedStringRenderable {
@@ -34,8 +34,9 @@ public extension DownAttributedStringRenderable {
      - returns: An `NSAttributedString`
      */
     
-    public func toAttributedString(_ options: DownOptions = .default) throws -> NSAttributedString {
+    public func toAttributedString(_ options: DownOptions = .default, stylesheet: String? = nil) throws -> NSAttributedString {
         let html = try self.toHTML(options)
-        return try NSAttributedString(htmlString: html)
+        let defaultStylesheet = "* {font-family: Helvetica } code, pre { font-family: Menlo }"
+        return try NSAttributedString(htmlString: "<style>" + (stylesheet ?? defaultStylesheet) + "</style>" + html)
     }
 }


### PR DESCRIPTION
The issue that I’m looking at here is somewhat subtle.  I’m mostly looking to start a conversation, at this point.  I’m not 100% sure the right way for Down.framework to approach this, so I’m presenting one possible method.


# The problem

There’s a lot of issues about fonts with NSAttributedString (#14, #15, #18, #21), so clearly there’s some frustration here.

The way Down.framework works right now is: `toAttributedString()` calls `toHTML()`, and then it makes an NSAttributedString from that.  This is an easy way to get from a valid Down object to a valid NSAttributedString object, and by Down’s policy of “it’s just a converter”, this is a solution.

The problem is with how NSAttributedString’s interface works.  Its default font (as documented in the API) is Helvetica 12, and so that's what you get if you make an NSAttributedString(string: “hello, world”).

But if you use the NSAttributedString(html:Data) initializer, this kicks it into some kind of special HTML rendering mode, which doesn’t use the default font.  It uses a tiny serif font.  Perhaps it’s trying to emulate Safari, which uses Times by default.


# Why Down.framework should care

I can see 3 reasons why Down.framework should get involved here.

First, Markdown is as much a plain text format as an HTML format.  People write it like plain text, and it’s designed to be perfectly readable that way.  (The existence of Down.framework reinforces this: it renders into 6 different formats, not just HTML.)  When people call `.toAttributedString()`, they aren’t asking for “an NSAttributedString of a Safari view of this Markdown”.  They want “an NSAttributedString of this Markdown”.

Second, for every other renderer, Down (like cmark) uses the default font of that backend.  The LaTeX output isn’t “LaTeX version of a Safari rendering of Markdown”.  It uses the default LaTeX font.

Third, it’s not so easy to change this from outside the library (the previous suggested approach).  NSAttributedString is immutable.  It’s possible to make a mutable copy and update the fonts, but (AFAICT) it’s really a lot of work.  (Personally, I’d write my own Markdown renderer before I went down that path.)  Fixing it from inside DownAttributedStringRenderable is easy.  Why bother providing an NSAttributedString renderer, if users are going to have to rewrite it themselves to make one that works the way they want?


# One solution

My proposed solution is straightforward.  Keep using the HTML data path, but prepend a tiny stylesheet which makes it use the default NSAttributedString font.  (Menlo, for monospaced text, isn’t a documented default of NSAttributedString, but it’s the standard monospaced font on macOS, and it’s a built-in font on every platform that Down supports.)

This PR makes the stylesheet an optional string, so it’s easy to get the previous Safari-like behavior, too, if you want that:

 - To use NSAttributedString’s default font, call .toAttributedString()
 - To use the Safari-style rendering, call .toAttributedString(stylesheet: "")
 - To use some other custom styles, call .toAttributedString(stylesheet: whateverYouWant)


I’m not entirely happy with this solution, but it’s simple, and provides the default font by default, and allows users to customize it if they need to.
