### PR TITLE
[Pods] Only include files in source_files that can be compiled

### DIFF
--- a/Down.podspec
+++ b/Down.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = "10.11"
   spec.requires_arc = true
   spec.module_name = "Down"
-  spec.preserve_paths = "Source/cmark/module.modulemap", "Source/cmark/*.inc"
+  spec.preserve_paths = "Source/cmark/module.modulemap", "Source/cmark/*.inc", "Source/cmark/COPYING"
   spec.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/Down/Source/cmark/**' }
   spec.ios.resource = 'Resources/DownView.bundle'
   spec.osx.resource = 'Resources/DownView.bundle'

--- a/Down.podspec
+++ b/Down.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.license      = { :type => "MIT", :file => "LICENSE" }
   spec.authors      = { "Rob Phillips" => "rob@robphillips.me" }
   spec.source       = { :git => "https://github.com/iwasrobbed/Down.git", :tag => "v" + spec.version.to_s }
-  spec.source_files = "Source/{cmark,Enums & Options,Extensions,Renderers}/**", "Source/*"
+  spec.source_files = "Source/{cmark,Enums & Options,Extensions,Renderers}/**/*.{h,c,swift}", "Source/*"
   spec.ios.source_files = "Source/Views/**"
   spec.osx.source_files = "Source/Views/**"
   spec.public_header_files = "Source/*.h"
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = "10.11"
   spec.requires_arc = true
   spec.module_name = "Down"
-  spec.preserve_path = 'Source/cmark/module.modulemap'
+  spec.preserve_paths = "Source/cmark/module.modulemap", "Source/cmark/*.inc"
   spec.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/Down/Source/cmark/**' }
   spec.ios.resource = 'Resources/DownView.bundle'
   spec.osx.resource = 'Resources/DownView.bundle'


### PR DESCRIPTION
These warnings are thrown by the compiler when including Down as a cocoapod:

![screen shot 2018-04-25 at 11 52 23](https://user-images.githubusercontent.com/1107150/39238677-25a9a034-487f-11e8-872b-13982bb28f2d.png)

By excluding files that should not be compiled from `spec.source_files`, we can prevent those warnings.