### PR TITLE
Updates the project settings to use the Legacy Build System.

### DIFF
--- a/Down.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Down.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
This fixes https://github.com/iwasrobbed/Down/issues/91 by changing the project's build settings to use the Legacy Build System.

This should avoid crashes under Xcode 10 Betas for now.

Credit/Thanks to @MrAlek for pointing out the fix. 👍