### PR TITLE
Add compiler flag to suppress implicit conversion warnings

### DIFF
--- a/Down.podspec
+++ b/Down.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |spec|
   spec.module_name = "Down"
   spec.preserve_paths = "Source/cmark/module.modulemap", "Source/cmark/*.inc", "Source/cmark/COPYING"
   spec.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/Down/Source/cmark/**' }
+  spec.compiler_flags = '-Wno-shorten-64-to-32'
   spec.ios.resource = 'Resources/DownView.bundle'
   spec.osx.resource = 'Resources/DownView.bundle'
 end


### PR DESCRIPTION
After recently importing the current version of cmark one compiler warning was fixed but five new ones appeared. I think this kind of whack-a-mole problem will continue as long as we're using cmark since it's C language and Down has different warnings enabled than the cmark developers do.

I've added a compiler flag to ignore the implicit integer conversion warnings. These are benign warnings and there's nothing really to be done about them in Down.  When this warning is disabled Down compiles without warnings.