### PR TITLE
Fix Swift module errors when used alongside Firestore

### DIFF
--- a/Source/cmark/buffer.c
+++ b/Source/cmark/buffer.c
@@ -10,7 +10,6 @@
 #include "config.h"
 #include "cmark_ctype.h"
 #include "buffer.h"
-#include "memory.h"
 
 /* Used as default value for cmark_strbuf->ptr so that people can always
  * assume ptr is non-NULL and zero terminated even for new cmark_strbufs.

--- a/Source/cmark/chunk.h
+++ b/Source/cmark/chunk.h
@@ -6,7 +6,6 @@
 #include <assert.h>
 #include "cmark.h"
 #include "buffer.h"
-#include "memory.h"
 #include "cmark_ctype.h"
 
 #define CMARK_CHUNK_EMPTY                                                      \

--- a/Source/cmark/iterator.h
+++ b/Source/cmark/iterator.h
@@ -6,7 +6,6 @@ extern "C" {
 #endif
 
 #include "cmark.h"
-#include "memory.h"
 
 typedef struct {
   cmark_event_type ev_type;

--- a/Source/cmark/parser.h
+++ b/Source/cmark/parser.h
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include "node.h"
 #include "buffer.h"
-#include "memory.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/Source/cmark/references.h
+++ b/Source/cmark/references.h
@@ -1,7 +1,6 @@
 #ifndef CMARK_REFERENCES_H
 #define CMARK_REFERENCES_H
 
-#include "memory.h"
 #include "chunk.h"
 
 #ifdef __cplusplus

--- a/Source/cmark/render.h
+++ b/Source/cmark/render.h
@@ -8,7 +8,6 @@ extern "C" {
 #include <stdlib.h>
 #include "buffer.h"
 #include "chunk.h"
-#include "memory.h"
 
 typedef enum { LITERAL, NORMAL, TITLE, URL } cmark_escaping;
 


### PR DESCRIPTION
First of all, thanks for this library, I've been happily using it for months. Recently I added `Firebase/Firestore` as a dependency, which caused very cryptic build errors on a swiftmodule level. I think the author of the vague #124 might be experiencing the same issue.

Turns out the `#include "memory.h"` references in libcmark confuse the compiler – it's picking up a different memory.h from gRPC (dependency of Firestore), and everything breaks. I think it is a leftover from an earlier version of libcmark that went unnoticed.

Either way, removing those rogue references solved the issue for me, without negatively affecting anything.

---

Until this gets merged or resolved in another way, my fork can be specified as a dependency like this as a workaround:

```
pod 'Down', :git => 'https://github.com/vzsg/Down.git', :branch => 'fix-cmark-imports'
```