### PR TITLE
Fix crash from missing parser.h include

### DIFF
--- a/Source/cmark/parser.h
+++ b/Source/cmark/parser.h
@@ -2,6 +2,7 @@
 #define CMARK_AST_H
 
 #include <stdio.h>
+#include "references.h"
 #include "node.h"
 #include "buffer.h"
 #include "memory.h"


### PR DESCRIPTION
The cmark file parser.h was missing a #include. This resulted in the compiler generating bad code for a reference to the mem struct. This caused men->free() to actually call mem->xcalloc() in the reference_free() function, which caused the crash. This has been fixed in the cmark project source code.