### PR TITLE
Wrap openURL so that Down compiles in app extensions

### DIFF
--- a/Source/Views/DownView.swift
+++ b/Source/Views/DownView.swift
@@ -174,14 +174,19 @@ extension DownView: WKNavigationDelegate {
             }
 
             decisionHandler(.cancel)
-            #if os(iOS)
-                UIApplication.shared.openURL(url)
-            #elseif os(macOS)
-                NSWorkspace.shared.open(url)
-            #endif
+            openURL(url: url)
         default:
             decisionHandler(.allow)
         }
+    }
+
+    @available(iOSApplicationExtension, unavailable)
+    func openURL(url: URL) {
+        #if os(iOS)
+            UIApplication.shared.openURL(url)
+        #elseif os(macOS)
+            NSWorkspace.shared.open(url)
+        #endif
     }
     
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -189,4 +194,11 @@ extension DownView: WKNavigationDelegate {
     }
     
 }
+
+fileprivate extension WKNavigationDelegate {
+    /// A wrapper for `UIApplication.shared.openURL` so that an empty default
+    /// implementation is available in app extensions
+    public func openURL(url: URL) {}
+}
+
 #endif


### PR DESCRIPTION
I'd like to use Down within the WordPress app, but the primary use would be in our share extension, when Markdown is imported from other apps.

Currently Down can't be used in app extensions because `DownView` uses `UIApplication.shared.openURL`, which isn't available in AppExtensions. With this change a wrapper method is used to allow `DownView` to compile and be usable in app extensions, with the concession that links cannot be opened in app extensions.

I'm open to suggestions on better ways to allow Down to be used in app extensions.