### PR TITLE
Added Down-iOS target

### DIFF
--- a/Down-iOS/Down_iOS.h
+++ b/Down-iOS/Down_iOS.h
@@ -1,0 +1,19 @@
+//
+//  Down_iOS.h
+//  Down-iOS
+//
+//  Created by David House on 4/13/19.
+//  Copyright © 2019 Glazed Donut, LLC. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Down_iOS.
+FOUNDATION_EXPORT double Down_iOSVersionNumber;
+
+//! Project version string for Down_iOS.
+FOUNDATION_EXPORT const unsigned char Down_iOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Down_iOS/PublicHeader.h>
+
+

--- a/Down-iOS/Info.plist
+++ b/Down-iOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017 Glazed Donut, LLC. All rights reserved.</string>
+</dict>
+</plist>

--- a/Down.xcodeproj/project.pbxproj
+++ b/Down.xcodeproj/project.pbxproj
@@ -66,6 +66,59 @@
 		8AFAEB091E6E331700E09B68 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D438696B1D00D27700E95A1F /* StringTests.swift */; };
 		907C64651EC133780095FEE1 /* TestDownView.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 907C64621EC120530095FEE1 /* TestDownView.bundle */; };
 		90A40A9C1EC03292004F2E91 /* Down.framework in Copy Bundled Frameworks */ = {isa = PBXBuildFile; fileRef = 8A569F401E6B3E50008BE2AC /* Down.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C3BEE0982262C4420068815C /* Down_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = C3BEE0962262C4420068815C /* Down_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3BEE09C2262C46F0068815C /* Down.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4201EF01CFA59F2008EEC6E /* Down.swift */; };
+		C3BEE09D2262C4740068815C /* DownErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44875E81CFA6CF30037A624 /* DownErrors.swift */; };
+		C3BEE09E2262C4760068815C /* DownOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44875E91CFA6CF30037A624 /* DownOptions.swift */; };
+		C3BEE09F2262C47A0068815C /* NSAttributedString+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43AE5C91CFFAE4D006E1522 /* NSAttributedString+HTML.swift */; };
+		C3BEE0A02262C47D0068815C /* String+ToHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43AE5DB1CFFD473006E1522 /* String+ToHTML.swift */; };
+		C3BEE0A12262C4810068815C /* DownASTRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D486E9951CFDD4860059FD7C /* DownASTRenderable.swift */; };
+		C3BEE0A22262C4830068815C /* DownAttributedStringRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CF88971CFFAC2C00F07FD1 /* DownAttributedStringRenderable.swift */; };
+		C3BEE0A32262C4860068815C /* DownCommonMarkRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DC91131CFDED4B0091CE09 /* DownCommonMarkRenderable.swift */; };
+		C3BEE0A42262C4880068815C /* DownGroffRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D486E9991CFDE28B0059FD7C /* DownGroffRenderable.swift */; };
+		C3BEE0A52262C48B0068815C /* DownHTMLRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44875E51CFA6B660037A624 /* DownHTMLRenderable.swift */; };
+		C3BEE0A62262C48D0068815C /* DownLaTeXRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D486E9971CFDE2730059FD7C /* DownLaTeXRenderable.swift */; };
+		C3BEE0A72262C48F0068815C /* DownXMLRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D486E9931CFDD33C0059FD7C /* DownXMLRenderable.swift */; };
+		C3BEE0A82262C4920068815C /* DownRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44875E31CFA6B200037A624 /* DownRenderable.swift */; };
+		C3BEE0A92262C4960068815C /* DownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43AE5D91CFFD0D0006E1522 /* DownView.swift */; };
+		C3BEE0AA2262C49F0068815C /* blocks.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201EF71CFA5D63008EEC6E /* blocks.c */; };
+		C3BEE0AB2262C4A20068815C /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201EF81CFA5D63008EEC6E /* buffer.c */; };
+		C3BEE0AC2262C4A50068815C /* buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201EF91CFA5D63008EEC6E /* buffer.h */; };
+		C3BEE0AD2262C4B40068815C /* chunk.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201EFB1CFA5D63008EEC6E /* chunk.h */; };
+		C3BEE0AE2262C4B70068815C /* cmark.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201EFC1CFA5D63008EEC6E /* cmark.c */; };
+		C3BEE0AF2262C4BA0068815C /* cmark.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201EFD1CFA5D63008EEC6E /* cmark.h */; };
+		C3BEE0B02262C4BD0068815C /* cmark_ctype.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201EFE1CFA5D63008EEC6E /* cmark_ctype.c */; };
+		C3BEE0B12262C4C10068815C /* cmark_ctype.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201EFF1CFA5D63008EEC6E /* cmark_ctype.h */; };
+		C3BEE0B22262C4C30068815C /* cmark_export.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F001CFA5D63008EEC6E /* cmark_export.h */; };
+		C3BEE0B32262C4C60068815C /* cmark_version.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F011CFA5D63008EEC6E /* cmark_version.h */; };
+		C3BEE0B42262C4C90068815C /* commonmark.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F021CFA5D63008EEC6E /* commonmark.c */; };
+		C3BEE0B52262C4CB0068815C /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F031CFA5D63008EEC6E /* config.h */; };
+		C3BEE0B62262C4CE0068815C /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F041CFA5D63008EEC6E /* debug.h */; };
+		C3BEE0B72262C4D00068815C /* houdini.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F061CFA5D63008EEC6E /* houdini.h */; };
+		C3BEE0B82262C4D30068815C /* houdini_href_e.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F071CFA5D63008EEC6E /* houdini_href_e.c */; };
+		C3BEE0B92262C4D60068815C /* houdini_html_e.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F081CFA5D63008EEC6E /* houdini_html_e.c */; };
+		C3BEE0BA2262C4D80068815C /* houdini_html_u.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F091CFA5D63008EEC6E /* houdini_html_u.c */; };
+		C3BEE0BB2262C4DB0068815C /* html.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F0A1CFA5D63008EEC6E /* html.c */; };
+		C3BEE0BC2262C4DD0068815C /* html_unescape.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F0B1CFA5D63008EEC6E /* html_unescape.h */; };
+		C3BEE0BD2262C4E00068815C /* inlines.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F0C1CFA5D63008EEC6E /* inlines.c */; };
+		C3BEE0BE2262C4E30068815C /* inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F0D1CFA5D63008EEC6E /* inlines.h */; };
+		C3BEE0BF2262C4E50068815C /* iterator.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F0E1CFA5D63008EEC6E /* iterator.c */; };
+		C3BEE0C02262C4E80068815C /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F0F1CFA5D63008EEC6E /* iterator.h */; };
+		C3BEE0C12262C4EB0068815C /* latex.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F101CFA5D63008EEC6E /* latex.c */; };
+		C3BEE0C22262C4EE0068815C /* man.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F111CFA5D63008EEC6E /* man.c */; };
+		C3BEE0C32262C4F50068815C /* node.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F131CFA5D63008EEC6E /* node.c */; };
+		C3BEE0C42262C4F70068815C /* node.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F141CFA5D63008EEC6E /* node.h */; };
+		C3BEE0C52262C4F90068815C /* parser.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F151CFA5D63008EEC6E /* parser.h */; };
+		C3BEE0C62262C4FC0068815C /* references.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F161CFA5D63008EEC6E /* references.c */; };
+		C3BEE0C72262C4FE0068815C /* references.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F171CFA5D63008EEC6E /* references.h */; };
+		C3BEE0C82262C5010068815C /* render.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F181CFA5D63008EEC6E /* render.c */; };
+		C3BEE0C92262C5040068815C /* render.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F191CFA5D63008EEC6E /* render.h */; };
+		C3BEE0CA2262C5070068815C /* scanners.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F1A1CFA5D63008EEC6E /* scanners.c */; };
+		C3BEE0CB2262C50A0068815C /* scanners.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F1B1CFA5D63008EEC6E /* scanners.h */; };
+		C3BEE0CC2262C50C0068815C /* utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F1C1CFA5D63008EEC6E /* utf8.c */; };
+		C3BEE0CD2262C50E0068815C /* utf8.h in Headers */ = {isa = PBXBuildFile; fileRef = D4201F1D1CFA5D63008EEC6E /* utf8.h */; };
+		C3BEE0CE2262C5110068815C /* xml.c in Sources */ = {isa = PBXBuildFile; fileRef = D4201F1E1CFA5D63008EEC6E /* xml.c */; };
+		C3BEE0CF2262C5250068815C /* DownView.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D41689B51CFFE6BB00E5802B /* DownView.bundle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -135,6 +188,9 @@
 		90A40A981EC0309A004F2E91 /* Deployment-Targets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Deployment-Targets.xcconfig"; sourceTree = "<group>"; };
 		90A40A991EC0309A004F2E91 /* Universal-Framework-Target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Universal-Framework-Target.xcconfig"; sourceTree = "<group>"; };
 		90A40A9A1EC0309A004F2E91 /* Universal-Target-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Universal-Target-Base.xcconfig"; sourceTree = "<group>"; };
+		C3BEE0942262C4420068815C /* Down.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Down.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C3BEE0962262C4420068815C /* Down_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Down_iOS.h; sourceTree = "<group>"; };
+		C3BEE0972262C4420068815C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D41689B21CFFE28200E5802B /* DownViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownViewTests.swift; sourceTree = "<group>"; };
 		D41689B51CFFE6BB00E5802B /* DownView.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = DownView.bundle; sourceTree = "<group>"; };
 		D4201EC51CFA59A5008EEC6E /* BindingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BindingTests.swift; sourceTree = "<group>"; };
@@ -204,6 +260,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C3BEE0912262C4420068815C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -225,6 +288,15 @@
 			path = Configurations;
 			sourceTree = "<group>";
 		};
+		C3BEE0952262C4420068815C /* Down-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				C3BEE0962262C4420068815C /* Down_iOS.h */,
+				C3BEE0972262C4420068815C /* Info.plist */,
+			);
+			path = "Down-iOS";
+			sourceTree = "<group>";
+		};
 		D41689B41CFFE6BB00E5802B /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -243,6 +315,7 @@
 				D4201E9B1CFA59A5008EEC6E /* Source */,
 				D41689B41CFFE6BB00E5802B /* Resources */,
 				D4201EC41CFA59A5008EEC6E /* Tests */,
+				C3BEE0952262C4420068815C /* Down-iOS */,
 				D4201E811CFA5151008EEC6E /* Products */,
 			);
 			indentWidth = 4;
@@ -254,6 +327,7 @@
 			children = (
 				8A569F401E6B3E50008BE2AC /* Down.framework */,
 				8AFAEAFB1E6E32E900E09B68 /* DownTests.xctest */,
+				C3BEE0942262C4420068815C /* Down.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -398,6 +472,32 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C3BEE08F2262C4420068815C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C3BEE0B62262C4CE0068815C /* debug.h in Headers */,
+				C3BEE0AD2262C4B40068815C /* chunk.h in Headers */,
+				C3BEE0C42262C4F70068815C /* node.h in Headers */,
+				C3BEE0B32262C4C60068815C /* cmark_version.h in Headers */,
+				C3BEE0C72262C4FE0068815C /* references.h in Headers */,
+				C3BEE0CB2262C50A0068815C /* scanners.h in Headers */,
+				C3BEE0AC2262C4A50068815C /* buffer.h in Headers */,
+				C3BEE0982262C4420068815C /* Down_iOS.h in Headers */,
+				C3BEE0BE2262C4E30068815C /* inlines.h in Headers */,
+				C3BEE0C92262C5040068815C /* render.h in Headers */,
+				C3BEE0B72262C4D00068815C /* houdini.h in Headers */,
+				C3BEE0CD2262C50E0068815C /* utf8.h in Headers */,
+				C3BEE0C52262C4F90068815C /* parser.h in Headers */,
+				C3BEE0C02262C4E80068815C /* iterator.h in Headers */,
+				C3BEE0B52262C4CB0068815C /* config.h in Headers */,
+				C3BEE0B22262C4C30068815C /* cmark_export.h in Headers */,
+				C3BEE0AF2262C4BA0068815C /* cmark.h in Headers */,
+				C3BEE0B12262C4C10068815C /* cmark_ctype.h in Headers */,
+				C3BEE0BC2262C4DD0068815C /* html_unescape.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -441,6 +541,24 @@
 			productReference = 8AFAEAFB1E6E32E900E09B68 /* DownTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		C3BEE0932262C4420068815C /* Down-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C3BEE09B2262C4420068815C /* Build configuration list for PBXNativeTarget "Down-iOS" */;
+			buildPhases = (
+				C3BEE08F2262C4420068815C /* Headers */,
+				C3BEE0902262C4420068815C /* Sources */,
+				C3BEE0912262C4420068815C /* Frameworks */,
+				C3BEE0922262C4420068815C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Down-iOS";
+			productName = "Down-iOS";
+			productReference = C3BEE0942262C4420068815C /* Down.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -461,6 +579,10 @@
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
+					C3BEE0932262C4420068815C = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = D4201E7A1CFA5151008EEC6E /* Build configuration list for PBXProject "Down" */;
@@ -478,6 +600,7 @@
 			targets = (
 				8A569F3F1E6B3E50008BE2AC /* Down */,
 				8AFAEAFA1E6E32E900E09B68 /* DownTests */,
+				C3BEE0932262C4420068815C /* Down-iOS */,
 			);
 		};
 /* End PBXProject section */
@@ -496,6 +619,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				907C64651EC133780095FEE1 /* TestDownView.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C3BEE0922262C4420068815C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C3BEE0CF2262C5250068815C /* DownView.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -575,6 +706,46 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C3BEE0902262C4420068815C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C3BEE0CE2262C5110068815C /* xml.c in Sources */,
+				C3BEE0B02262C4BD0068815C /* cmark_ctype.c in Sources */,
+				C3BEE0B82262C4D30068815C /* houdini_href_e.c in Sources */,
+				C3BEE0A42262C4880068815C /* DownGroffRenderable.swift in Sources */,
+				C3BEE09F2262C47A0068815C /* NSAttributedString+HTML.swift in Sources */,
+				C3BEE0A52262C48B0068815C /* DownHTMLRenderable.swift in Sources */,
+				C3BEE0AB2262C4A20068815C /* buffer.c in Sources */,
+				C3BEE0A32262C4860068815C /* DownCommonMarkRenderable.swift in Sources */,
+				C3BEE0A92262C4960068815C /* DownView.swift in Sources */,
+				C3BEE0B92262C4D60068815C /* houdini_html_e.c in Sources */,
+				C3BEE09D2262C4740068815C /* DownErrors.swift in Sources */,
+				C3BEE0A02262C47D0068815C /* String+ToHTML.swift in Sources */,
+				C3BEE0AE2262C4B70068815C /* cmark.c in Sources */,
+				C3BEE0A82262C4920068815C /* DownRenderable.swift in Sources */,
+				C3BEE0C82262C5010068815C /* render.c in Sources */,
+				C3BEE0C32262C4F50068815C /* node.c in Sources */,
+				C3BEE09E2262C4760068815C /* DownOptions.swift in Sources */,
+				C3BEE0A12262C4810068815C /* DownASTRenderable.swift in Sources */,
+				C3BEE0CA2262C5070068815C /* scanners.c in Sources */,
+				C3BEE0C22262C4EE0068815C /* man.c in Sources */,
+				C3BEE0B42262C4C90068815C /* commonmark.c in Sources */,
+				C3BEE09C2262C46F0068815C /* Down.swift in Sources */,
+				C3BEE0BF2262C4E50068815C /* iterator.c in Sources */,
+				C3BEE0BB2262C4DB0068815C /* html.c in Sources */,
+				C3BEE0C62262C4FC0068815C /* references.c in Sources */,
+				C3BEE0A62262C48D0068815C /* DownLaTeXRenderable.swift in Sources */,
+				C3BEE0C12262C4EB0068815C /* latex.c in Sources */,
+				C3BEE0AA2262C49F0068815C /* blocks.c in Sources */,
+				C3BEE0BD2262C4E00068815C /* inlines.c in Sources */,
+				C3BEE0A22262C4830068815C /* DownAttributedStringRenderable.swift in Sources */,
+				C3BEE0A72262C48F0068815C /* DownXMLRenderable.swift in Sources */,
+				C3BEE0CC2262C50C0068815C /* utf8.c in Sources */,
+				C3BEE0BA2262C4D80068815C /* houdini_html_u.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -649,6 +820,66 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.glazeddonut.DownTests;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		C3BEE0992262C4420068815C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Down-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.glazeddonut.Down;
+				PRODUCT_NAME = Down;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/Source/cmark";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C3BEE09A2262C4420068815C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Down-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.glazeddonut.Down;
+				PRODUCT_NAME = Down;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/Source/cmark";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -792,6 +1023,15 @@
 			buildConfigurations = (
 				8AFAEB041E6E32E900E09B68 /* Debug */,
 				8AFAEB051E6E32E900E09B68 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C3BEE09B2262C4420068815C /* Build configuration list for PBXNativeTarget "Down-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C3BEE0992262C4420068815C /* Debug */,
+				C3BEE09A2262C4420068815C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
When integrating Down directly into an app by including the Down project, there is currently no iOS target, only a macOS target. This PR just adds the Down-iOS target so you can use that in your iOS app when you include Down. I tested it in my iOS app and it seems to work fine.

This shouldn't have an affect on Cocoapods integration as that method essentially creates its own target when integrating into the app. Not sure about Carthage because I don't use it.