### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Pods/
+.build/
 .DS_Store
 xcuserdata
 

--- a/Down.podspec
+++ b/Down.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = "10.11"
   spec.requires_arc = true
   spec.module_name = "Down"
-  spec.preserve_paths = "Source/cmark/module.modulemap", "Source/cmark/*.inc", "Source/cmark/COPYING"
+  spec.preserve_paths = "Source/cmark/include/module.modulemap", "Source/cmark/*.inc", "Source/cmark/COPYING"
   spec.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/Down/Source/cmark/**' }
   spec.compiler_flags = '-Wno-shorten-64-to-32'
   spec.ios.resource = 'Resources/DownView.bundle'

--- a/Down.xcodeproj/project.pbxproj
+++ b/Down.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		14C5E33621877FCD00D5380C /* DownView (macOS).bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "DownView (macOS).bundle"; sourceTree = "<group>"; };
 		8A569F401E6B3E50008BE2AC /* Down.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Down.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AFAEAFB1E6E32E900E09B68 /* DownTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DownTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8C73B9B522A687C400C8E60F /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		907C64621EC120530095FEE1 /* TestDownView.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = TestDownView.bundle; sourceTree = "<group>"; };
 		90A40A951EC02FF6004F2E91 /* Down-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Down-Info.plist"; sourceTree = "<group>"; };
 		90A40A961EC02FF6004F2E91 /* DownTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "DownTests-Info.plist"; sourceTree = "<group>"; };
@@ -199,7 +200,6 @@
 		D4201F1C1CFA5D63008EEC6E /* utf8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf8.c; sourceTree = "<group>"; };
 		D4201F1D1CFA5D63008EEC6E /* utf8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utf8.h; sourceTree = "<group>"; };
 		D4201F1E1CFA5D63008EEC6E /* xml.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xml.c; sourceTree = "<group>"; };
-		D42869501CFF501200FACB4C /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		D438696B1D00D27700E95A1F /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		D43AE5C91CFFAE4D006E1522 /* NSAttributedString+HTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+HTML.swift"; sourceTree = "<group>"; };
 		D43AE5D91CFFD0D0006E1522 /* DownView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownView.swift; sourceTree = "<group>"; };
@@ -257,6 +257,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8C73B9B422A687C400C8E60F /* include */ = {
+			isa = PBXGroup;
+			children = (
+				8C73B9B522A687C400C8E60F /* module.modulemap */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
 		907C64611EC120530095FEE1 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
@@ -339,6 +347,7 @@
 		D4201EF61CFA5D63008EEC6E /* cmark */ = {
 			isa = PBXGroup;
 			children = (
+				8C73B9B422A687C400C8E60F /* include */,
 				D4201EF71CFA5D63008EEC6E /* blocks.c */,
 				D4201EF81CFA5D63008EEC6E /* buffer.c */,
 				D4201EF91CFA5D63008EEC6E /* buffer.h */,
@@ -362,7 +371,6 @@
 				D4201F0F1CFA5D63008EEC6E /* iterator.h */,
 				D4201F101CFA5D63008EEC6E /* latex.c */,
 				D4201F111CFA5D63008EEC6E /* man.c */,
-				D42869501CFF501200FACB4C /* module.modulemap */,
 				D4201F131CFA5D63008EEC6E /* node.c */,
 				D4201F141CFA5D63008EEC6E /* node.h */,
 				D4201F151CFA5D63008EEC6E /* parser.h */,

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Down",
+    platforms: [
+        .macOS("10.11"),
+        .iOS("9.0"),
+        .tvOS("9.0"),
+        .watchOS("2.0"),
+    ],
+    products: [
+    .library(
+        name: "Down",
+        targets: ["Down"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "libcmark",
+            dependencies: [],
+            path: "Source/cmark"),
+        .target(
+            name: "Down",
+            dependencies: ["libcmark"],
+            path: "Source/",
+            exclude: ["cmark", "Down.h"]),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -26,5 +26,10 @@ let package = Package(
             dependencies: ["libcmark"],
             path: "Source/",
             exclude: ["cmark", "Down.h"]),
+        .testTarget(
+            name: "DownTests",
+            dependencies: ["Down"],
+            path: "Tests/",
+            exclude: ["Fixtures", "DownViewTests.swift"]),
     ]
 )

--- a/Source/cmark/include/module.modulemap
+++ b/Source/cmark/include/module.modulemap
@@ -1,4 +1,4 @@
 module libcmark [system][extern_c] {
-    header "node.h"
+    header "../node.h"
     export *
 }


### PR DESCRIPTION
Adds SPM support. The main change this required was moving the cmark module map to the include directory. This is required by SPM for C languages.