### PR TITLE
Create Public Initializer for DebugVisitor

### DIFF
--- a/Source/AST/Visitors/DebugVisitor.swift
+++ b/Source/AST/Visitors/DebugVisitor.swift
@@ -18,6 +18,8 @@ public class DebugVisitor {
     private var indent: String {
         return String(repeating: "    ", count: depth)
     }
+
+    public init() {}
     
     /// Debug representation of node.
     private func report(_ node: Node) -> String {


### PR DESCRIPTION
I updated DebugVisitor. I added a public initializer to allow
DebugVisitor to be used by applications that consume the Down framework
for generating debug output from Markdown ASTs.

Fixes #152 