### PR TITLE
[SPM] Fixes error with missing headers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,9 @@ let package = Package(
         .target(
             name: "libcmark",
             dependencies: [],
-            path: "Source/cmark"),
+            path: "Source/cmark",
+            exclude: ["include"],
+            publicHeadersPath: "./"),
         .target(
             name: "Down",
             dependencies: ["libcmark"],


### PR DESCRIPTION
This fixes #151 

It was solved by adding the cmark directory into the publicHeadersPath. The include directory had to be excluded to avoid SPM conflicts with include paths.