### PR TITLE
Fix permissions error on Catalina beta 2

### DIFF
--- a/Source/Views/DownView.swift
+++ b/Source/Views/DownView.swift
@@ -95,7 +95,7 @@ open class DownView: WKWebView {
     private lazy var temporaryDirectoryURL: URL = {
         return try! FileManager.default.url(for: .itemReplacementDirectory,
                                             in: .userDomainMask,
-                                            appropriateFor: URL(fileURLWithPath: "/"),
+                                            appropriateFor: URL(fileURLWithPath: NSTemporaryDirectory()),
                                             create: true).appendingPathComponent("Down", isDirectory: true)
     }()
     #endif


### PR DESCRIPTION
This started happening randomly on beta 2. I'm hoping that my system isn't borked. But this fixes the error. 🤷🏻‍♂️

```
Fatal error: 'try!' expression unexpectedly raised an error: Error Domain=NSCocoaErrorDomain Code=642 "You can’t save the file “Macintosh HD” because the volume “Macintosh HD” is read only." UserInfo={NSURL=file:///, NSUnderlyingError=0x100b42ac0 {Error Domain=NSPOSIXErrorDomain Code=30 "Read-only file system"}}: file /Users/mdiep/Repositories/iwasrobbed/Down/Source/Views/DownView.swift, line 96
```