### PR TITLE
Automatically indent nested list

### DIFF
--- a/Source/AST/Visitors/AttributedStringVisitor.swift
+++ b/Source/AST/Visitors/AttributedStringVisitor.swift
@@ -15,7 +15,8 @@ public class AttributedStringVisitor {
     
     private let styler: Styler
     private let options: DownOptions
-    
+    private var listLevel: Int = -1
+
     /// Creates a new instance with the given styler and options.
     ///
     /// - parameters:
@@ -44,14 +45,18 @@ extension AttributedStringVisitor: Visitor {
     }
     
     public func visit(list node: List) -> NSMutableAttributedString {
+        listLevel += 1
         let items = visitChildren(of: node)
         
         // Prepend prefixes to each item.
         items.enumerated().forEach { index, item in
+            var tabs = ""
+            (0..<listLevel).forEach {_ in tabs.append("\t") }
+
             let prefix: String
             switch node.listType {
-            case .bullet: prefix = "•\t"
-            case .ordered(let start): prefix = "\(start + index).\t"
+            case .bullet: prefix = "\(tabs)•\t"
+            case .ordered(let start): prefix = "\(tabs)\(start + index).\t"
             }
             
             let attrPrefix = NSAttributedString(string: prefix, attributes: styler.listPrefixAttributes)
@@ -61,6 +66,8 @@ extension AttributedStringVisitor: Visitor {
         let s = items.joined
         if node.hasSuccessor { s.append(.paragraphSeparator) }
         styler.style(list: s)
+
+        listLevel -= 1
         return s
     }
     


### PR DESCRIPTION
Related to #138 to indent nested list.

I've added a counter to indent the content of nested lists.

To get a good result with the Styler:
```
var defaultParagraphStyle: NSMutableParagraphStyle {
    let paragraphStyle = NSMutableParagraphStyle()
    paragraphStyle.paragraphSpacing = 16
    paragraphStyle.lineSpacing = 0

    return paragraphStyle
  }

func style(list str: NSMutableAttributedString) {
    let paragraphStyle = defaultParagraphStyle

    paragraphStyle.headIndent = 28
    paragraphStyle.firstLineHeadIndent = 0
    paragraphStyle.defaultTabInterval = 36

    str.addAttributes([.paragraphStyle: paragraphStyle])
    str.fixAttributes(in: NSRange(location: 0, length: str.length))
  }

func style(item str: NSMutableAttributedString) {
    str.addAttributes([.paragraphStyle: defaultParagraphStyle])
    str.fixAttributes(in: NSRange(location: 0, length: str.length))
  }
```

Also, there's many ways to achieve that. One of them is to add 2 more functions on `Styler` protocol:
```
func move(in node: Node)
func exiting(from node: Node)
```

It allow to implement the list counter outside the Down framework