### PR TITLE
Updates for unsafe option

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,17 @@ public static let hardBreaks = DownOptions(rawValue: 1 << 2)
  `file:`, and `data:`, except for `image/png`, `image/gif`,
  `image/jpeg`, or `image/webp` mime types).  Raw HTML is replaced
  by a placeholder HTML comment. Unsafe links are replaced by
- empty strings.
+ empty strings. Note that this option is provided for backwards
+ compatibility, but safe mode is now the default. 
 */
 public static let safe = DownOptions(rawValue: 1 << 3)
+
+/**
+ Allow raw HTML and unsafe links. Note that safe mode is now 
+ the default, and the unsafe option must be used if rendering
+ of raw HTML and unsafe links is desired. 
+*/
+public static let unsafe = DownOptions(rawValue: 1 << 17)
 
 // MARK: - Parsing Options
 
@@ -220,6 +228,11 @@ public static let validateUTF8 = DownOptions(rawValue: 1 << 5)
  Convert straight quotes to curly, --- to em dashes, -- to en dashes.
 */
 public static let smart = DownOptions(rawValue: 1 << 6)
+
+/**
+ Combine smart typography with HTML rendering. 
+*/
+public static let smartUnsaFe = DownOptions(rawValue: (1 << 17) + (1 << 6))
 ```
 
 ### Supports

--- a/Source/Enums & Options/DownOptions.swift
+++ b/Source/Enums & Options/DownOptions.swift
@@ -54,5 +54,10 @@ public struct DownOptions: OptionSet {
 
     /// Convert straight quotes to curly, --- to em dashes, -- to en dashes.
     public static let smart = DownOptions(rawValue: CMARK_OPT_SMART)
+    
+    // MARK: - Combo Options
+    
+    /// Combines 'unsafe' and 'smart' to render raw HTML and produce smart typography.
+    public static let smartUnsafe = DownOptions(rawValue: CMARK_OPT_SMART + CMARK_OPT_UNSAFE)
 
 }


### PR DESCRIPTION
Updating README and DownOptions to show that safe mode is now the default, and to indicate that unsafe must be specified to allow HTML rendering.