### PR TITLE
Basic support for attributed string images (iOS only)

### DIFF
--- a/Source/AST/Visitors/AttributedStringVisitor.swift
+++ b/Source/AST/Visitors/AttributedStringVisitor.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+#if os(iOS)
+import MobileCoreServices
+import UIKit
+#endif
+
 /// This class is used to generated an `NSMutableAttributedString` from the abstract syntax
 /// tree produced by a markdown string. It traverses the tree to construct substrings
 /// represented at each node and uses an instance of `Styler` to apply the visual attributes.
@@ -164,10 +169,29 @@ extension AttributedStringVisitor: Visitor {
     }
     
     public func visit(image node: Image) -> NSMutableAttributedString {
-        let s = visitChildren(of: node).joined
-        styler.style(image: s, title: node.title, url: node.url)
-        return s
-    }
+		let s = visitChildren(of: node).joined
+		#if os(iOS)		//Limited to iOS here due to CoreServices (UTType) and UIKit (NSTextAttachment) requirements
+		if let urlString = node.url,
+			let url = URL(string: urlString),
+			let imageData = try? Data(contentsOf: url) {
+			let attachmentType: String?
+			if url.pathExtension.isEmpty {
+				if urlString.contains("image/gif") {
+					attachmentType = "com.compuserve.gif"
+				} else {
+					attachmentType = nil
+				}
+			} else {
+				let pathExtension = url.pathExtension as CFString
+				attachmentType = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension, nil)?.takeRetainedValue() as String?
+			}
+			let attachment = NSTextAttachment(data: imageData, ofType: attachmentType)
+			s.append(NSAttributedString(attachment: attachment))
+		}
+		#endif
+		styler.style(image: s, title: node.title, url: node.url)
+		return s
+	}
 }
 
 // MARK: - Helper extentions


### PR DESCRIPTION
Adds limited support for images in attributed strings. Limited to iOS due to CoreServices (UTType) and UIKit (NSTextAttachment) requirements.