### PR TITLE
Don't compile NSAttributedString extension on Linux

### DIFF
--- a/Source/Extensions/NSAttributedString+HTML.swift
+++ b/Source/Extensions/NSAttributedString+HTML.swift
@@ -8,10 +8,9 @@
 
 #if os(macOS)
     import AppKit
-#else
+#elseif os(iOS) || os(tvOS)
     import UIKit
 #endif
-
 
 extension NSAttributedString {
 
@@ -24,11 +23,16 @@ extension NSAttributedString {
             throw DownErrors.htmlDataConversionError
         }
 
+        #if !os(Linux)
         let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
             .documentType: NSAttributedString.DocumentType.html,
             .characterEncoding: NSNumber(value: String.Encoding.utf8.rawValue)
         ]
         try self.init(data: data, options: options, documentAttributes: nil)
+        #else
+        // NSAttributedString.DocumentReadingOptionKey is not
+        // available in Linux, so throw an error instead.
+        throw DownErrors.htmlDataConversionError
+        #endif
     }
-
 }

--- a/Source/Views/DownView.swift
+++ b/Source/Views/DownView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016-2019 Glazed Donut, LLC. All rights reserved.
 //
 
-#if os(tvOS) || os(watchOS)
+#if os(tvOS) || os(watchOS) || os(Linux)
     // Sorry, not available for tvOS nor watchOS
 #else
 import WebKit


### PR DESCRIPTION
I ran into an issue where I couldn't use `Down` when deploying to Vapor Cloud (e.g., Linux).

I implemented a fix similar to what I found [here](https://github.com/JohnSundell/Splash/blob/master/Sources/Splash/Theming/Color.swift), I think this fix is pretty self-explanatory.
