### PR TITLE
Minor documentation fix

### DIFF
--- a/Source/Renderers/DownAttributedStringRenderable.swift
+++ b/Source/Renderers/DownAttributedStringRenderable.swift
@@ -42,7 +42,7 @@ extension DownAttributedStringRenderable {
     /// - Parameters:
     ///   - options: `DownOptions` to modify parsing or rendering
     ///   - styler: a class/struct conforming to `Styler` to use when rendering the various elements of the attributed string
-    /// - Returns: `DownErrors` depending on the scenario
+    /// - Returns: An `NSAttributedString`
     /// - Throws: `DownErrors` depending on the scenario
     public func toAttributedString(_ options: DownOptions = .default, styler: Styler) throws -> NSAttributedString {
         let tree = try self.toAST(options)


### PR DESCRIPTION
Seems to have been a bad copy & paste. I think it's returning an attributed string :)