### PR TITLE
Make color & font collection initializers public

### DIFF
--- a/Source/AST/Styling/Attribute Collections/ColorCollection.swift
+++ b/Source/AST/Styling/Attribute Collections/ColorCollection.swift
@@ -37,17 +37,43 @@ public protocol ColorCollection {
 
 public struct StaticColorCollection: ColorCollection {
 
-    public var heading1 = DownColor.black
-    public var heading2 = DownColor.black
-    public var heading3 = DownColor.black
-    public var body = DownColor.black
-    public var code = DownColor.black
-    public var link = DownColor.systemBlue
-    public var quote = DownColor.darkGray
-    public var quoteStripe = DownColor.darkGray
-    public var thematicBreak = DownColor(white: 0.9, alpha: 1)
-    public var listItemPrefix = DownColor.lightGray
-    public var codeBlockBackground = DownColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1)
+    public var heading1: DownColor
+    public var heading2: DownColor
+    public var heading3: DownColor
+    public var body: DownColor
+    public var code: DownColor
+    public var link: DownColor
+    public var quote: DownColor
+    public var quoteStripe: DownColor
+    public var thematicBreak: DownColor
+    public var listItemPrefix: DownColor
+    public var codeBlockBackground: DownColor
+
+    public init(
+        heading1: DownColor = .black,
+        heading2: DownColor = .black,
+        heading3: DownColor = .black,
+        body: DownColor = .black,
+        code: DownColor = .black,
+        link: DownColor = .blue,
+        quote: DownColor = .darkGray,
+        quoteStripe: DownColor = .darkGray,
+        thematicBreak: DownColor = .init(white: 0.9, alpha: 1),
+        listItemPrefix: DownColor = .lightGray,
+        codeBlockBackground: DownColor = .init(red: 0.96, green: 0.97, blue: 0.98, alpha: 1)
+    ) {
+        self.heading1 = heading1
+        self.heading2 = heading2
+        self.heading3 = heading3
+        self.body = body
+        self.code = code
+        self.link = link
+        self.quote = quote
+        self.quoteStripe = quoteStripe
+        self.thematicBreak = thematicBreak
+        self.listItemPrefix = listItemPrefix
+        self.codeBlockBackground = codeBlockBackground
+    }
 }
 
 #endif

--- a/Source/AST/Styling/Attribute Collections/FontCollection.swift
+++ b/Source/AST/Styling/Attribute Collections/FontCollection.swift
@@ -32,12 +32,28 @@ public protocol FontCollection {
 
 public struct StaticFontCollection: FontCollection {
 
-    public var heading1 = DownFont.boldSystemFont(ofSize: 28)
-    public var heading2 = DownFont.boldSystemFont(ofSize: 24)
-    public var heading3 = DownFont.boldSystemFont(ofSize: 20)
-    public var body = DownFont.systemFont(ofSize: 17)
-    public var code = DownFont(name: "menlo", size: 17) ?? .systemFont(ofSize: 17)
-    public var listItemPrefix = DownFont.monospacedDigitSystemFont(ofSize: 17, weight: .regular)
+    public var heading1: DownFont
+    public var heading2: DownFont
+    public var heading3: DownFont
+    public var body: DownFont
+    public var code: DownFont
+    public var listItemPrefix: DownFont
+
+    public init(
+        heading1: DownFont = .boldSystemFont(ofSize: 28),
+        heading2: DownFont = .boldSystemFont(ofSize: 24),
+        heading3: DownFont = .boldSystemFont(ofSize: 20),
+        body: DownFont = .systemFont(ofSize: 17),
+        code: DownFont = DownFont(name: "menlo", size: 17) ?? .systemFont(ofSize: 17),
+        listItemPrefix: DownFont = DownFont.monospacedDigitSystemFont(ofSize: 17, weight: .regular)
+    ) {
+        self.heading1 = heading1
+        self.heading2 = heading2
+        self.heading3 = heading3
+        self.body = body
+        self.code = code
+        self.listItemPrefix = listItemPrefix
+    }
 }
 
 #endif


### PR DESCRIPTION
# What's in this PR?

A small fix for https://github.com/iwasrobbed/Down/issues/182

## Issues

The initializers for `StaticColorCollection` and `StaticFontCollection` are not publicly accessible, thus their properties could not be set.

## Causes

The generated memberwise struct initializer is internal by default, even if the struct has public access.

## Solutions

Explicitly define public memberwise initializers with default values.