### PR TITLE
Improve configurability of DownStyler

### DIFF
--- a/Source/AST/Styling/Attribute Collections/ParagraphStyleCollection.swift
+++ b/Source/AST/Styling/Attribute Collections/ParagraphStyleCollection.swift
@@ -18,7 +18,16 @@ import AppKit
 
 #endif
 
-public struct ParagraphStyleCollection {
+public protocol ParagraphStyleCollection {
+
+    var heading1: NSParagraphStyle { get }
+    var heading2: NSParagraphStyle { get }
+    var heading3: NSParagraphStyle { get }
+    var body: NSParagraphStyle { get }
+    var code: NSParagraphStyle { get }
+}
+
+public struct StaticParagraphStyleCollection: ParagraphStyleCollection {
 
     public var heading1: NSParagraphStyle
     public var heading2: NSParagraphStyle

--- a/Source/AST/Styling/Helpers/ListItemParagraphStyler.swift
+++ b/Source/AST/Styling/Helpers/ListItemParagraphStyler.swift
@@ -22,12 +22,12 @@ import AppKit
 /// are right aligned and list item content left aligns.
 public class ListItemParagraphStyler {
 
-    var indentation: CGFloat {
+    public var indentation: CGFloat {
         return largestPrefixWidth + options.spacingAfterPrefix
     }
 
     /// The paragraph style intended for all paragraphs excluding the first.
-    var trailingParagraphStyle: NSParagraphStyle {
+    public var trailingParagraphStyle: NSParagraphStyle {
         let contentIndentation = indentation
         let style = baseStyle
         style.firstLineHeadIndent = contentIndentation
@@ -54,7 +54,7 @@ public class ListItemParagraphStyler {
     /// The paragraph style intended for the first paragraph of the list item.
     /// 
     /// - Parameter prefixWidth: the width (in points) of the list item prefix.
-    func leadingParagraphStyle(prefixWidth: CGFloat) -> NSParagraphStyle {
+    public func leadingParagraphStyle(prefixWidth: CGFloat) -> NSParagraphStyle {
         let contentIndentation = indentation
         let prefixIndentation: CGFloat = contentIndentation - options.spacingAfterPrefix - prefixWidth
         let prefixSpill = max(0, prefixWidth - largestPrefixWidth)

--- a/Source/AST/Styling/Options/CodeBlockOptions.swift
+++ b/Source/AST/Styling/Options/CodeBlockOptions.swift
@@ -20,7 +20,11 @@ import AppKit
 
 public struct CodeBlockOptions {
 
-    public var containerInset: CGFloat = 8
+    public var containerInset: CGFloat
+
+    public init(containerInset: CGFloat = 8) {
+        self.containerInset = containerInset
+    }
 }
 
 #endif

--- a/Source/AST/Styling/Options/ListItemOptions.swift
+++ b/Source/AST/Styling/Options/ListItemOptions.swift
@@ -20,10 +20,21 @@ import AppKit
 
 public struct ListItemOptions {
 
-    public var maxPrefixDigits: UInt = 2
-    public var spacingAfterPrefix: CGFloat = 8
-    public var spacingAbove: CGFloat = 4
-    public var spacingBelow: CGFloat = 8
+    public var maxPrefixDigits: UInt
+    public var spacingAfterPrefix: CGFloat
+    public var spacingAbove: CGFloat
+    public var spacingBelow: CGFloat
+
+    public init(maxPrefixDigits: UInt = 2,
+                spacingAfterPrefix: CGFloat = 8,
+                spacingAbove: CGFloat = 4,
+                spacingBelow: CGFloat = 8
+    ) {
+        self.maxPrefixDigits = maxPrefixDigits
+        self.spacingAfterPrefix = spacingAfterPrefix
+        self.spacingAbove = spacingAbove
+        self.spacingBelow = spacingBelow
+    }
 }
 
 #endif

--- a/Source/AST/Styling/Options/QuoteStripeOptions.swift
+++ b/Source/AST/Styling/Options/QuoteStripeOptions.swift
@@ -20,8 +20,13 @@ import AppKit
 
 public struct QuoteStripeOptions {
 
-    public var thickness: CGFloat = 2
-    public var spacingAfter: CGFloat = 8
+    public var thickness: CGFloat
+    public var spacingAfter: CGFloat
+
+    public init(thickness: CGFloat = 2, spacingAfter: CGFloat = 8) {
+        self.thickness = thickness
+        self.spacingAfter = spacingAfter
+    }
 }
 
 #endif

--- a/Source/AST/Styling/Options/ThematicBreakOptions.swift
+++ b/Source/AST/Styling/Options/ThematicBreakOptions.swift
@@ -20,8 +20,13 @@ import AppKit
 
 public struct ThematicBreakOptions {
 
-    public var thickness: CGFloat = 1
-    public var indentation: CGFloat = 0
+    public var thickness: CGFloat
+    public var indentation: CGFloat
+
+    public init(thickness: CGFloat = 1, indentation: CGFloat = 0) {
+        self.thickness = thickness
+        self.indentation = indentation
+    }
 }
 
 #endif

--- a/Source/AST/Styling/Stylers/DownStylerConfiguration.swift
+++ b/Source/AST/Styling/Stylers/DownStylerConfiguration.swift
@@ -22,7 +22,7 @@ public struct DownStylerConfiguration {
 
     public init(fonts: FontCollection = StaticFontCollection(),
                 colors: ColorCollection = StaticColorCollection(),
-                paragraphStyles: ParagraphStyleCollection = ParagraphStyleCollection(),
+                paragraphStyles: ParagraphStyleCollection = StaticParagraphStyleCollection(),
                 listItemOptions: ListItemOptions = ListItemOptions(),
                 quoteStripeOptions: QuoteStripeOptions = QuoteStripeOptions(),
                 thematicBreakOptions: ThematicBreakOptions = ThematicBreakOptions(),

--- a/Source/AST/Styling/Stylers/DownStylerConfiguration.swift
+++ b/Source/AST/Styling/Stylers/DownStylerConfiguration.swift
@@ -11,16 +11,31 @@
 /// A configuration object used to initialze the `DownStyler`.
 public struct DownStylerConfiguration {
     
-    public var fonts: FontCollection = StaticFontCollection()
-    public var colors: ColorCollection = StaticColorCollection()
-    public var paragraphStyles = ParagraphStyleCollection()
+    public var fonts: FontCollection
+    public var colors: ColorCollection
+    public var paragraphStyles: ParagraphStyleCollection
     
-    public var listItemOptions = ListItemOptions()
-    public var quoteStripeOptions = QuoteStripeOptions()
-    public var thematicBreakOptions = ThematicBreakOptions()
-    public var codeBlockOptions = CodeBlockOptions()
+    public var listItemOptions: ListItemOptions
+    public var quoteStripeOptions: QuoteStripeOptions
+    public var thematicBreakOptions: ThematicBreakOptions
+    public var codeBlockOptions: CodeBlockOptions
 
-    public init() {}
+    public init(fonts: FontCollection = StaticFontCollection(),
+                colors: ColorCollection = StaticColorCollection(),
+                paragraphStyles: ParagraphStyleCollection = ParagraphStyleCollection(),
+                listItemOptions: ListItemOptions = ListItemOptions(),
+                quoteStripeOptions: QuoteStripeOptions = QuoteStripeOptions(),
+                thematicBreakOptions: ThematicBreakOptions = ThematicBreakOptions(),
+                codeBlockOptions: CodeBlockOptions = CodeBlockOptions()
+    ) {
+        self.fonts = fonts
+        self.colors = colors
+        self.paragraphStyles = paragraphStyles
+        self.listItemOptions = listItemOptions
+        self.quoteStripeOptions = quoteStripeOptions
+        self.thematicBreakOptions = thematicBreakOptions
+        self.codeBlockOptions = codeBlockOptions
+    }
 }
 
 #endif

--- a/Tests/Styler/StylerTestSuite.swift
+++ b/Tests/Styler/StylerTestSuite.swift
@@ -114,7 +114,7 @@ private extension DownStylerConfiguration {
         colors.thematicBreak = #colorLiteral(red: 0.3647058904, green: 0.06666667014, blue: 0.9686274529, alpha: 1)
         colors.listItemPrefix = .gray
 
-        var paragraphStyles = ParagraphStyleCollection()
+        var paragraphStyles = StaticParagraphStyleCollection()
         let headingParagraphStyle = NSMutableParagraphStyle()
         headingParagraphStyle.paragraphSpacing = 8
 


### PR DESCRIPTION
Extends configurability of `DownStyler` and extends #184

- adds public, memberwise initializers for styling options
- adds public, memberwise initializers for `DownStylerConfiguration`
- makes `ParagraphStyleCollection` a protocol and adds `StaticParagraphStyleCollection` to match other attribute collections
- makes properties and methods of `ListItemParagraphStyler` public