### PR TITLE
Make QuoteStripeAttribute etc. conforming to NSCoding for Core Data

### DIFF
--- a/Source/AST/Styling/Custom Attributes/BlockBackgroundColorAttribute.swift
+++ b/Source/AST/Styling/Custom Attributes/BlockBackgroundColorAttribute.swift
@@ -18,10 +18,24 @@ import AppKit
 
 #endif
 
-struct BlockBackgroundColorAttribute {
-
+public class BlockBackgroundColorAttribute : NSObject, NSCoding {
     var color: DownColor
     var inset: CGFloat
+  
+    init(color: DownColor, inset: CGFloat) {
+        self.color = color
+        self.inset = inset
+    }
+  
+    public func encode(with coder: NSCoder) {
+        coder.encode(color, forKey: "color")
+        coder.encode(inset, forKey: "inset")
+    }
+    
+    public required init?(coder: NSCoder) {
+        color = coder.decodeObject(forKey: "color") as? DownColor ?? DownColor()
+        inset = coder.decodeObject(forKey: "inset") as? CGFloat ?? 0.0
+    }
 }
 
 extension NSAttributedString.Key {

--- a/Source/AST/Styling/Custom Attributes/QuoteStripeAttribute.swift
+++ b/Source/AST/Styling/Custom Attributes/QuoteStripeAttribute.swift
@@ -18,7 +18,7 @@ import AppKit
 
 #endif
 
-struct QuoteStripeAttribute {
+public class QuoteStripeAttribute : NSObject, NSCoding {
 
     var color: DownColor
     var thickness: CGFloat
@@ -28,17 +28,38 @@ struct QuoteStripeAttribute {
     var layoutWidth: CGFloat {
         return thickness + spacingAfter
     }
+    
+    public func encode(with coder: NSCoder) {
+      coder.encode(color, forKey: "color")
+      coder.encode(thickness, forKey: "thickness")
+      coder.encode(spacingAfter, forKey: "spacingAfter")
+      coder.encode(locations, forKey: "locations")
+    }
+    
+    public required init?(coder: NSCoder) {
+      color = coder.decodeObject(forKey: "color") as? DownColor ?? DownColor()
+      thickness = coder.decodeObject(forKey: "thickness") as? CGFloat ?? 0.0
+      spacingAfter = coder.decodeObject(forKey: "spacingAfter") as? CGFloat ?? 0.0
+      locations = coder.decodeObject(forKey: "locations") as? [CGFloat] ?? [CGFloat]()
+    }
+
+    init(color: DownColor, thickness: CGFloat, spacingAfter: CGFloat, locations: [CGFloat]) {
+      self.color = color
+      self.thickness = thickness
+      self.spacingAfter = spacingAfter
+      self.locations = locations
+    }
 }
 
 extension QuoteStripeAttribute {
 
-    init(level: Int, color: DownColor, options: QuoteStripeOptions) {
+    convenience init(level: Int, color: DownColor, options: QuoteStripeOptions) {
         self.init(color: color, thickness: options.thickness, spacingAfter: options.spacingAfter, locations: [])
         locations = (0..<level).map { CGFloat($0) * layoutWidth }
     }
 
     func indented(by indentation: CGFloat) -> QuoteStripeAttribute {
-        var copy = self
+        let copy = self
         copy.locations = locations.map { $0 + indentation }
         return copy
     }

--- a/Source/AST/Styling/Custom Attributes/ThematicBreakAttribute.swift
+++ b/Source/AST/Styling/Custom Attributes/ThematicBreakAttribute.swift
@@ -18,10 +18,24 @@ import AppKit
 
 #endif
 
-struct ThematicBreakAttribute {
-
+public class ThematicBreakAttribute : NSObject, NSCoding {
     var thickness: CGFloat
     var color: DownColor
+    
+    init(thickness: CGFloat, color: DownColor) {
+      self.color = color
+      self.thickness = thickness
+    }
+  
+    public func encode(with coder: NSCoder) {
+      coder.encode(color, forKey: "color")
+      coder.encode(thickness, forKey: "thickness")
+    }
+  
+    public required init?(coder: NSCoder) {
+      color = coder.decodeObject(forKey: "color") as? DownColor ?? DownColor()
+      thickness = coder.decodeObject(forKey: "thickness") as? CGFloat ?? 0.0
+    }
 }
 
 extension NSAttributedString.Key {


### PR DESCRIPTION
Hello, first of all thanks for this nice project!

When I tried to save the rendered `NSAttributedString` into Core Data as one `String` and one `transformable` with type `[NSRange : [NSAttributedString.Key : Any]]`, I had crashes with certain texts. I found out that it is because `QuoteStripeAttribute`, `BlockBackgroundColorAttribute` and `ThematicBreakAttribute` are not classes conforming to `NSCoding`. 

I tried to make them into `NSCoding` classes in order to save the dictionary as `transformable`.
