### PR TITLE
Make BaseNode init accessible outside the Down module

### DIFF
--- a/Source/AST/Nodes/BaseNode.swift
+++ b/Source/AST/Nodes/BaseNode.swift
@@ -42,7 +42,7 @@ public class BaseNode: Node {
         return depth
     }()
     
-    init(cmarkNode: CMarkNode) {
+    public init(cmarkNode: CMarkNode) {
         self.cmarkNode = cmarkNode
     }
     


### PR DESCRIPTION
This pull request adds the public designator to the BaseNode.init initializer so that it can be called outside the Down module.

Fixes #196