### PR TITLE
Resolves Swift Package Manager issue related to swift-snapshot-testing

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [
         .macOS("10.11"),
         .iOS("9.0"),
-        .tvOS("9.0"),
-        .watchOS("2.0")
+        .tvOS("9.0")
     ],
     products: [
         .library(
@@ -16,7 +15,6 @@ let package = Package(
             targets: ["Down"]
         )
     ],
-    dependencies: [],
     targets: [
         .target(
             name: "libcmark",
@@ -50,5 +48,6 @@ let package = Package(
                 "Styler/ThematicBreakSyleTests.swift"
             ]
         )
-    ]
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -8,12 +8,13 @@ let package = Package(
         .macOS("10.11"),
         .iOS("9.0"),
         .tvOS("9.0"),
-        .watchOS("2.0"),
+        .watchOS("2.0")
     ],
     products: [
-    .library(
-        name: "Down",
-        targets: ["Down"]),
+        .library(
+            name: "Down",
+            targets: ["Down"]
+        )
     ],
     dependencies: [],
     targets: [
@@ -22,16 +23,19 @@ let package = Package(
             dependencies: [],
             path: "Source/cmark",
             exclude: ["include"],
-            publicHeadersPath: "./"),
+            publicHeadersPath: "./"
+        ),
         .target(
             name: "Down",
             dependencies: ["libcmark"],
             path: "Source/",
-            exclude: ["cmark", "Down.h"]),
+            exclude: ["cmark", "Down.h"]
+        ),
         .testTarget(
             name: "DownTests",
             dependencies: ["Down"],
             path: "Tests/",
-            exclude: ["Fixtures", "DownViewTests.swift"]),
+            exclude: ["Fixtures", "DownViewTests.swift"]
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,20 @@ let package = Package(
             name: "DownTests",
             dependencies: ["Down"],
             path: "Tests/",
-            exclude: ["Fixtures", "DownViewTests.swift"]
+            exclude: [
+                "AST/VisitorTests.swift",
+                "DownViewTests.swift",
+                "Fixtures",
+                "Styler/BlockQuoteStyleTests.swift",
+                "Styler/CodeBlockStyleTests.swift",
+                "Styler/DownDebugLayoutManagerTests.swift",
+                "Styler/HeadingStyleTests.swift",
+                "Styler/LinkStyleTests.swift",
+                "Styler/InlineStyleTests.swift",
+                "Styler/ListItemStyleTests.swift",
+                "Styler/StylerTestSuite.swift",
+                "Styler/ThematicBreakSyleTests.swift"
+            ]
         )
     ]
 )


### PR DESCRIPTION
### Summary
This pull request proposes a solution for #202, which identified an issue where the framework would fail to build when the package was opened via `xed`.

### Details

- The root cause of the issue was that some files in the test target referenced `SnapshotTesting`.
- Expressing `SnapshotTesting` as a dependency would require changes to the minimum deployment targets of the framework, and might also required updates to the reference snapshots.
- This approach excludes the files from the test target that imported `SnapshotTesting`, allowing the existing minimum deployment targets to be preserved.

### Testing

The branch should build & tests should pass.