### PR TITLE
Add styling options for level 4 to 6 headings

### DIFF
--- a/Source/AST/Styling/Attribute Collections/ColorCollection.swift
+++ b/Source/AST/Styling/Attribute Collections/ColorCollection.swift
@@ -25,6 +25,9 @@ public protocol ColorCollection {
     var heading1: DownColor { get }
     var heading2: DownColor { get }
     var heading3: DownColor { get }
+    var heading4: DownColor { get }
+    var heading5: DownColor { get }
+    var heading6: DownColor { get }
     var body: DownColor { get }
     var code: DownColor { get }
     var link: DownColor { get }
@@ -40,6 +43,9 @@ public struct StaticColorCollection: ColorCollection {
     public var heading1: DownColor
     public var heading2: DownColor
     public var heading3: DownColor
+    public var heading4: DownColor
+    public var heading5: DownColor
+    public var heading6: DownColor
     public var body: DownColor
     public var code: DownColor
     public var link: DownColor
@@ -53,6 +59,9 @@ public struct StaticColorCollection: ColorCollection {
         heading1: DownColor = .black,
         heading2: DownColor = .black,
         heading3: DownColor = .black,
+        heading4: DownColor = .black,
+        heading5: DownColor = .black,
+        heading6: DownColor = .black,
         body: DownColor = .black,
         code: DownColor = .black,
         link: DownColor = .blue,
@@ -65,6 +74,9 @@ public struct StaticColorCollection: ColorCollection {
         self.heading1 = heading1
         self.heading2 = heading2
         self.heading3 = heading3
+        self.heading4 = heading4
+        self.heading5 = heading5
+        self.heading6 = heading6
         self.body = body
         self.code = code
         self.link = link

--- a/Source/AST/Styling/Attribute Collections/FontCollection.swift
+++ b/Source/AST/Styling/Attribute Collections/FontCollection.swift
@@ -25,6 +25,9 @@ public protocol FontCollection {
     var heading1: DownFont { get }
     var heading2: DownFont { get }
     var heading3: DownFont { get }
+    var heading4: DownFont { get }
+    var heading5: DownFont { get }
+    var heading6: DownFont { get }
     var body: DownFont { get }
     var code: DownFont { get }
     var listItemPrefix: DownFont { get }
@@ -35,6 +38,9 @@ public struct StaticFontCollection: FontCollection {
     public var heading1: DownFont
     public var heading2: DownFont
     public var heading3: DownFont
+    public var heading4: DownFont
+    public var heading5: DownFont
+    public var heading6: DownFont
     public var body: DownFont
     public var code: DownFont
     public var listItemPrefix: DownFont
@@ -43,6 +49,9 @@ public struct StaticFontCollection: FontCollection {
         heading1: DownFont = .boldSystemFont(ofSize: 28),
         heading2: DownFont = .boldSystemFont(ofSize: 24),
         heading3: DownFont = .boldSystemFont(ofSize: 20),
+        heading4: DownFont = .boldSystemFont(ofSize: 20),
+        heading5: DownFont = .boldSystemFont(ofSize: 20),
+        heading6: DownFont = .boldSystemFont(ofSize: 20),
         body: DownFont = .systemFont(ofSize: 17),
         code: DownFont = DownFont(name: "menlo", size: 17) ?? .systemFont(ofSize: 17),
         listItemPrefix: DownFont = DownFont.monospacedDigitSystemFont(ofSize: 17, weight: .regular)
@@ -50,6 +59,9 @@ public struct StaticFontCollection: FontCollection {
         self.heading1 = heading1
         self.heading2 = heading2
         self.heading3 = heading3
+        self.heading4 = heading4
+        self.heading5 = heading5
+        self.heading6 = heading6
         self.body = body
         self.code = code
         self.listItemPrefix = listItemPrefix

--- a/Source/AST/Styling/Attribute Collections/ParagraphStyleCollection.swift
+++ b/Source/AST/Styling/Attribute Collections/ParagraphStyleCollection.swift
@@ -23,6 +23,9 @@ public protocol ParagraphStyleCollection {
     var heading1: NSParagraphStyle { get }
     var heading2: NSParagraphStyle { get }
     var heading3: NSParagraphStyle { get }
+    var heading4: NSParagraphStyle { get }
+    var heading5: NSParagraphStyle { get }
+    var heading6: NSParagraphStyle { get }
     var body: NSParagraphStyle { get }
     var code: NSParagraphStyle { get }
 }
@@ -32,6 +35,9 @@ public struct StaticParagraphStyleCollection: ParagraphStyleCollection {
     public var heading1: NSParagraphStyle
     public var heading2: NSParagraphStyle
     public var heading3: NSParagraphStyle
+    public var heading4: NSParagraphStyle
+    public var heading5: NSParagraphStyle
+    public var heading6: NSParagraphStyle
     public var body: NSParagraphStyle
     public var code: NSParagraphStyle
 
@@ -51,6 +57,9 @@ public struct StaticParagraphStyleCollection: ParagraphStyleCollection {
         heading1 = headingStyle
         heading2 = headingStyle
         heading3 = headingStyle
+        heading4 = headingStyle
+        heading5 = headingStyle
+        heading6 = headingStyle
         body = bodyStyle
         code = codeStyle
     }

--- a/Source/AST/Styling/Stylers/DownStyler.swift
+++ b/Source/AST/Styling/Stylers/DownStyler.swift
@@ -221,7 +221,10 @@ open class DownStyler: Styler {
         switch level {
         case 1: return (fonts.heading1, colors.heading1, paragraphStyles.heading1)
         case 2: return (fonts.heading2, colors.heading2, paragraphStyles.heading2)
-        case 3...6: return (fonts.heading3, colors.heading3, paragraphStyles.heading3)
+        case 3: return (fonts.heading3, colors.heading3, paragraphStyles.heading3)
+        case 4: return (fonts.heading4, colors.heading4, paragraphStyles.heading4)
+        case 5: return (fonts.heading5, colors.heading5, paragraphStyles.heading5)
+        case 6: return (fonts.heading6, colors.heading6, paragraphStyles.heading6)
         default: return (fonts.heading1, colors.heading1, paragraphStyles.heading1)
         }
     }

--- a/Tests/Styler/StylerTestSuite.swift
+++ b/Tests/Styler/StylerTestSuite.swift
@@ -108,9 +108,9 @@ private extension DownStylerConfiguration {
         colors.heading1 = #colorLiteral(red: 0.7803921569, green: 0, blue: 0.2235294118, alpha: 1)
         colors.heading2 = #colorLiteral(red: 1, green: 0.3411764706, blue: 0.2, alpha: 1)
         colors.heading3 = #colorLiteral(red: 1, green: 0.7647058824, blue: 0.05882352941, alpha: 1)
-        colors.heading4 = #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1)
-        colors.heading5 = #colorLiteral(red: 0.9568627477, green: 0.6588235497, blue: 0.5450980663, alpha: 1)
-        colors.heading6 = #colorLiteral(red: 0.9098039269, green: 0.4784313738, blue: 0.6431372762, alpha: 1)
+        colors.heading4 = #colorLiteral(red: 1, green: 0.7647058824, blue: 0.05882352941, alpha: 1)
+        colors.heading5 = #colorLiteral(red: 1, green: 0.7647058824, blue: 0.05882352941, alpha: 1)
+        colors.heading6 = #colorLiteral(red: 1, green: 0.7647058824, blue: 0.05882352941, alpha: 1)
         colors.body = .black
         colors.code = .darkGray
         colors.codeBlockBackground = #colorLiteral(red: 0.9647058824, green: 0.9725490196, blue: 0.9803921569, alpha: 1)

--- a/Tests/Styler/StylerTestSuite.swift
+++ b/Tests/Styler/StylerTestSuite.swift
@@ -97,6 +97,9 @@ private extension DownStylerConfiguration {
         fonts.heading1 = .systemFont(ofSize: 28)
         fonts.heading2 = .systemFont(ofSize: 24)
         fonts.heading3 = .systemFont(ofSize: 20)
+        fonts.heading4 = .systemFont(ofSize: 20)
+        fonts.heading5 = .systemFont(ofSize: 20)
+        fonts.heading6 = .systemFont(ofSize: 20)
         fonts.body = .systemFont(ofSize: 17)
         fonts.code = UIFont(name: "menlo", size: 17)!
         fonts.listItemPrefix = .monospacedDigitSystemFont(ofSize: 17, weight: .regular)
@@ -105,6 +108,9 @@ private extension DownStylerConfiguration {
         colors.heading1 = #colorLiteral(red: 0.7803921569, green: 0, blue: 0.2235294118, alpha: 1)
         colors.heading2 = #colorLiteral(red: 1, green: 0.3411764706, blue: 0.2, alpha: 1)
         colors.heading3 = #colorLiteral(red: 1, green: 0.7647058824, blue: 0.05882352941, alpha: 1)
+        colors.heading4 = #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1)
+        colors.heading5 = #colorLiteral(red: 0.9568627477, green: 0.6588235497, blue: 0.5450980663, alpha: 1)
+        colors.heading6 = #colorLiteral(red: 0.9098039269, green: 0.4784313738, blue: 0.6431372762, alpha: 1)
         colors.body = .black
         colors.code = .darkGray
         colors.codeBlockBackground = #colorLiteral(red: 0.9647058824, green: 0.9725490196, blue: 0.9803921569, alpha: 1)
@@ -125,6 +131,9 @@ private extension DownStylerConfiguration {
         paragraphStyles.heading1 = headingParagraphStyle
         paragraphStyles.heading2 = headingParagraphStyle
         paragraphStyles.heading3 = headingParagraphStyle
+        paragraphStyles.heading4 = headingParagraphStyle
+        paragraphStyles.heading5 = headingParagraphStyle
+        paragraphStyles.heading6 = headingParagraphStyle
         paragraphStyles.body = bodyParagraphStyle
         paragraphStyles.code = bodyParagraphStyle
 


### PR DESCRIPTION
As of now, headings have the same style for levels 3 to 6.
This pull request adds customization points to style level 4 to 6 headings.
By default, level 4 to 6 headings will have the same style as a level 3 heading. So the current behavior will not be modified.