### PR TITLE
[Improvement] Expose DownTextView's designated initializer

### DIFF
--- a/Source/AST/Styling/Text Views/DownTextView.swift
+++ b/Source/AST/Styling/Text Views/DownTextView.swift
@@ -54,7 +54,7 @@ open class DownTextView: TextView {
         self.init(frame: frame, styler: styler, layoutManager: DownLayoutManager())
     }
 
-    init(frame: CGRect, styler: Styler, layoutManager: NSLayoutManager) {
+    public init(frame: CGRect, styler: Styler, layoutManager: NSLayoutManager) {
         self.styler = styler
 
         let textStorage = NSTextStorage()


### PR DESCRIPTION
change designated initializer visibility to public to allow using inititializers in `DownTextView` subclasses