### PR TITLE
Added example for working with SwiftUI

### DIFF
--- a/Down-Example/Down-Example.xcodeproj/project.pbxproj
+++ b/Down-Example/Down-Example.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		6DAF6A1F26665FCA0066FAFD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAF6A1E26665FCA0066FAFD /* ContentView.swift */; };
 		6DAF6A2126665FCB0066FAFD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DAF6A2026665FCB0066FAFD /* Assets.xcassets */; };
 		6DAF6A2426665FCB0066FAFD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DAF6A2326665FCB0066FAFD /* Preview Assets.xcassets */; };
+		6DAF6A2B2666616D0066FAFD /* DownHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAF6A2A2666616D0066FAFD /* DownHTML.swift */; };
+		6DAF6A2C266662F90066FAFD /* Down.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D49980B51FA560F8004EE42E /* Down.framework */; };
+		6DAF6A2D266662F90066FAFD /* Down.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D49980B51FA560F8004EE42E /* Down.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DAF6A2F266665DE0066FAFD /* README-sample.md in Resources */ = {isa = PBXBuildFile; fileRef = 14954EA421A7DCA3001933C4 /* README-sample.md */; };
 		8A07D7D31F085EC6004D7141 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07D7D21F085EC6004D7141 /* AppDelegate.swift */; };
 		8A07D7D51F085EC6004D7141 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07D7D41F085EC6004D7141 /* ViewController.swift */; };
 		8A07D7D81F085EC6004D7141 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A07D7D61F085EC6004D7141 /* Main.storyboard */; };
@@ -71,6 +75,17 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6DAF6A2E266662F90066FAFD /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				6DAF6A2D266662F90066FAFD /* Down.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D4591EA0226D293F00EBD476 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -99,6 +114,7 @@
 		6DAF6A2026665FCB0066FAFD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6DAF6A2326665FCB0066FAFD /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6DAF6A2526665FCB0066FAFD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6DAF6A2A2666616D0066FAFD /* DownHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownHTML.swift; sourceTree = "<group>"; };
 		8A07D7CF1F085EC6004D7141 /* Down-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Down-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A07D7D21F085EC6004D7141 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A07D7D41F085EC6004D7141 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -122,6 +138,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DAF6A2C266662F90066FAFD /* Down.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,6 +189,7 @@
 				6DAF6A2026665FCB0066FAFD /* Assets.xcassets */,
 				6DAF6A2526665FCB0066FAFD /* Info.plist */,
 				6DAF6A2226665FCB0066FAFD /* Preview Content */,
+				6DAF6A2A2666616D0066FAFD /* DownHTML.swift */,
 			);
 			path = "Down-SwiftUI-Example";
 			sourceTree = "<group>";
@@ -258,6 +276,7 @@
 				6DAF6A1626665FCA0066FAFD /* Sources */,
 				6DAF6A1726665FCA0066FAFD /* Frameworks */,
 				6DAF6A1826665FCA0066FAFD /* Resources */,
+				6DAF6A2E266662F90066FAFD /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -376,6 +395,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DAF6A2F266665DE0066FAFD /* README-sample.md in Resources */,
 				6DAF6A2426665FCB0066FAFD /* Preview Assets.xcassets in Resources */,
 				6DAF6A2126665FCB0066FAFD /* Assets.xcassets in Resources */,
 			);
@@ -410,6 +430,7 @@
 			files = (
 				6DAF6A1F26665FCA0066FAFD /* ContentView.swift in Sources */,
 				6DAF6A1D26665FCA0066FAFD /* Down_SwiftUI_ExampleApp.swift in Sources */,
+				6DAF6A2B2666616D0066FAFD /* DownHTML.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Down-Example/Down-Example.xcodeproj/project.pbxproj
+++ b/Down-Example/Down-Example.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		1466417F218D2A18009627F9 /* Down.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D49980B51FA560F8004EE42E /* Down.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		14954EA521A7DCB9001933C4 /* README-sample.md in Resources */ = {isa = PBXBuildFile; fileRef = 14954EA421A7DCA3001933C4 /* README-sample.md */; };
 		14954EA621A7DCBA001933C4 /* README-sample.md in Resources */ = {isa = PBXBuildFile; fileRef = 14954EA421A7DCA3001933C4 /* README-sample.md */; };
+		6DAF6A1D26665FCA0066FAFD /* Down_SwiftUI_ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAF6A1C26665FCA0066FAFD /* Down_SwiftUI_ExampleApp.swift */; };
+		6DAF6A1F26665FCA0066FAFD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAF6A1E26665FCA0066FAFD /* ContentView.swift */; };
+		6DAF6A2126665FCB0066FAFD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DAF6A2026665FCB0066FAFD /* Assets.xcassets */; };
+		6DAF6A2426665FCB0066FAFD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DAF6A2326665FCB0066FAFD /* Preview Assets.xcassets */; };
 		8A07D7D31F085EC6004D7141 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07D7D21F085EC6004D7141 /* AppDelegate.swift */; };
 		8A07D7D51F085EC6004D7141 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07D7D41F085EC6004D7141 /* ViewController.swift */; };
 		8A07D7D81F085EC6004D7141 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A07D7D61F085EC6004D7141 /* Main.storyboard */; };
@@ -53,13 +57,6 @@
 			remoteGlobalIDString = 8AFAEAFB1E6E32E900E09B68;
 			remoteInfo = DownTests;
 		};
-		D4C77E06240EEB64004675B3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D49980AF1FA560F8004EE42E /* Down.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EEBA153A2344845500B54ECB;
-			remoteInfo = DownSnapshotTests;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -96,6 +93,12 @@
 		14090A542185411A00503C06 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14090A5E2185443800503C06 /* macOS Demo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "macOS Demo.entitlements"; sourceTree = "<group>"; };
 		14954EA421A7DCA3001933C4 /* README-sample.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "README-sample.md"; sourceTree = "<group>"; };
+		6DAF6A1A26665FCA0066FAFD /* Down-SwiftUI-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Down-SwiftUI-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DAF6A1C26665FCA0066FAFD /* Down_SwiftUI_ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Down_SwiftUI_ExampleApp.swift; sourceTree = "<group>"; };
+		6DAF6A1E26665FCA0066FAFD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		6DAF6A2026665FCB0066FAFD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6DAF6A2326665FCB0066FAFD /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		6DAF6A2526665FCB0066FAFD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A07D7CF1F085EC6004D7141 /* Down-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Down-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A07D7D21F085EC6004D7141 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A07D7D41F085EC6004D7141 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -112,6 +115,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4591E9C226D293F00EBD476 /* Down.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6DAF6A1726665FCA0066FAFD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -154,6 +164,26 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
+		6DAF6A1B26665FCA0066FAFD /* Down-SwiftUI-Example */ = {
+			isa = PBXGroup;
+			children = (
+				6DAF6A1C26665FCA0066FAFD /* Down_SwiftUI_ExampleApp.swift */,
+				6DAF6A1E26665FCA0066FAFD /* ContentView.swift */,
+				6DAF6A2026665FCB0066FAFD /* Assets.xcassets */,
+				6DAF6A2526665FCB0066FAFD /* Info.plist */,
+				6DAF6A2226665FCB0066FAFD /* Preview Content */,
+			);
+			path = "Down-SwiftUI-Example";
+			sourceTree = "<group>";
+		};
+		6DAF6A2226665FCB0066FAFD /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				6DAF6A2326665FCB0066FAFD /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
 		8A07D7C61F085EC6004D7141 = {
 			isa = PBXGroup;
 			children = (
@@ -161,6 +191,7 @@
 				8A07D7D11F085EC6004D7141 /* Down-Example */,
 				14090A4A2185411800503C06 /* macOS Demo */,
 				14954EA321A7DCA3001933C4 /* Shared */,
+				6DAF6A1B26665FCA0066FAFD /* Down-SwiftUI-Example */,
 				14664175218D264A009627F9 /* Frameworks */,
 				8A07D7D01F085EC6004D7141 /* Products */,
 			);
@@ -171,6 +202,7 @@
 			children = (
 				8A07D7CF1F085EC6004D7141 /* Down-Example.app */,
 				14090A492185411800503C06 /* macOS Demo.app */,
+				6DAF6A1A26665FCA0066FAFD /* Down-SwiftUI-Example.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -193,7 +225,6 @@
 			children = (
 				D49980B51FA560F8004EE42E /* Down.framework */,
 				D49980B71FA560F8004EE42E /* DownTests.xctest */,
-				D4C77E07240EEB64004675B3 /* DownSnapshotTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -218,6 +249,23 @@
 			name = "macOS Demo";
 			productName = "macOS Demo";
 			productReference = 14090A492185411800503C06 /* macOS Demo.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6DAF6A1926665FCA0066FAFD /* Down-SwiftUI-Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6DAF6A2926665FCB0066FAFD /* Build configuration list for PBXNativeTarget "Down-SwiftUI-Example" */;
+			buildPhases = (
+				6DAF6A1626665FCA0066FAFD /* Sources */,
+				6DAF6A1726665FCA0066FAFD /* Frameworks */,
+				6DAF6A1826665FCA0066FAFD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Down-SwiftUI-Example";
+			productName = "Down-SwiftUI-Example";
+			productReference = 6DAF6A1A26665FCA0066FAFD /* Down-SwiftUI-Example.app */;
 			productType = "com.apple.product-type.application";
 		};
 		8A07D7CE1F085EC6004D7141 /* Down-Example */ = {
@@ -245,7 +293,7 @@
 		8A07D7C71F085EC6004D7141 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1000;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Down;
 				TargetAttributes = {
@@ -259,6 +307,10 @@
 								enabled = 1;
 							};
 						};
+					};
+					6DAF6A1926665FCA0066FAFD = {
+						CreatedOnToolsVersion = 12.5;
+						ProvisioningStyle = Automatic;
 					};
 					8A07D7CE1F085EC6004D7141 = {
 						CreatedOnToolsVersion = 8.3.3;
@@ -287,6 +339,7 @@
 			targets = (
 				8A07D7CE1F085EC6004D7141 /* Down-Example */,
 				14090A482185411800503C06 /* macOS Demo */,
+				6DAF6A1926665FCA0066FAFD /* Down-SwiftUI-Example */,
 			);
 		};
 /* End PBXProject section */
@@ -306,13 +359,6 @@
 			remoteRef = D49980B61FA560F8004EE42E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		D4C77E07240EEB64004675B3 /* DownSnapshotTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = DownSnapshotTests.xctest;
-			remoteRef = D4C77E06240EEB64004675B3 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -323,6 +369,15 @@
 				14090A502185411A00503C06 /* Assets.xcassets in Resources */,
 				14090A532185411A00503C06 /* Main.storyboard in Resources */,
 				14954EA521A7DCB9001933C4 /* README-sample.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6DAF6A1826665FCA0066FAFD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DAF6A2426665FCB0066FAFD /* Preview Assets.xcassets in Resources */,
+				6DAF6A2126665FCB0066FAFD /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -346,6 +401,15 @@
 			files = (
 				14090A4E2185411800503C06 /* ViewController.swift in Sources */,
 				14090A4C2185411800503C06 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6DAF6A1626665FCA0066FAFD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DAF6A1F26665FCA0066FAFD /* ContentView.swift in Sources */,
+				6DAF6A1D26665FCA0066FAFD /* Down_SwiftUI_ExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -451,6 +515,55 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		6DAF6A2626665FCB0066FAFD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Down-SwiftUI-Example/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Down-SwiftUI-Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.downMarkdown..Down-SwiftUI-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6DAF6A2726665FCB0066FAFD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Down-SwiftUI-Example/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Down-SwiftUI-Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.downMarkdown..Down-SwiftUI-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -617,6 +730,15 @@
 			buildConfigurations = (
 				14090A572185411A00503C06 /* Debug */,
 				14090A582185411A00503C06 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6DAF6A2926665FCB0066FAFD /* Build configuration list for PBXNativeTarget "Down-SwiftUI-Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DAF6A2626665FCB0066FAFD /* Debug */,
+				6DAF6A2726665FCB0066FAFD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Down-Example/Down-Example.xcodeproj/project.pbxproj
+++ b/Down-Example/Down-Example.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		6DAF6A2C266662F90066FAFD /* Down.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D49980B51FA560F8004EE42E /* Down.framework */; };
 		6DAF6A2D266662F90066FAFD /* Down.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D49980B51FA560F8004EE42E /* Down.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6DAF6A2F266665DE0066FAFD /* README-sample.md in Resources */ = {isa = PBXBuildFile; fileRef = 14954EA421A7DCA3001933C4 /* README-sample.md */; };
+		6DAF6A3126666C440066FAFD /* DownAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAF6A3026666C440066FAFD /* DownAttributedString.swift */; };
 		8A07D7D31F085EC6004D7141 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07D7D21F085EC6004D7141 /* AppDelegate.swift */; };
 		8A07D7D51F085EC6004D7141 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07D7D41F085EC6004D7141 /* ViewController.swift */; };
 		8A07D7D81F085EC6004D7141 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A07D7D61F085EC6004D7141 /* Main.storyboard */; };
@@ -115,6 +116,7 @@
 		6DAF6A2326665FCB0066FAFD /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6DAF6A2526665FCB0066FAFD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6DAF6A2A2666616D0066FAFD /* DownHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownHTML.swift; sourceTree = "<group>"; };
+		6DAF6A3026666C440066FAFD /* DownAttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownAttributedString.swift; sourceTree = "<group>"; };
 		8A07D7CF1F085EC6004D7141 /* Down-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Down-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A07D7D21F085EC6004D7141 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A07D7D41F085EC6004D7141 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 				6DAF6A2526665FCB0066FAFD /* Info.plist */,
 				6DAF6A2226665FCB0066FAFD /* Preview Content */,
 				6DAF6A2A2666616D0066FAFD /* DownHTML.swift */,
+				6DAF6A3026666C440066FAFD /* DownAttributedString.swift */,
 			);
 			path = "Down-SwiftUI-Example";
 			sourceTree = "<group>";
@@ -428,6 +431,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DAF6A3126666C440066FAFD /* DownAttributedString.swift in Sources */,
 				6DAF6A1F26665FCA0066FAFD /* ContentView.swift in Sources */,
 				6DAF6A1D26665FCA0066FAFD /* Down_SwiftUI_ExampleApp.swift in Sources */,
 				6DAF6A2B2666616D0066FAFD /* DownHTML.swift in Sources */,

--- a/Down-Example/Down-Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Down-Example/Down-Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Down-Example.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Down-Example/Down-SwiftUI-Example/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Down-Example/Down-SwiftUI-Example/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Down-Example/Down-SwiftUI-Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Down-Example/Down-SwiftUI-Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Down-Example/Down-SwiftUI-Example/Assets.xcassets/Contents.json
+++ b/Down-Example/Down-SwiftUI-Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Down-Example/Down-SwiftUI-Example/ContentView.swift
+++ b/Down-Example/Down-SwiftUI-Example/ContentView.swift
@@ -1,0 +1,22 @@
+//
+//  ContentView.swift
+//  Down-SwiftUI-Example
+//
+//  Created by Mikhail Ivanov on 01.06.2021.
+//  Copyright © 2021 Down. All rights reserved.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Down-Example/Down-SwiftUI-Example/ContentView.swift
+++ b/Down-Example/Down-SwiftUI-Example/ContentView.swift
@@ -51,11 +51,7 @@ struct ContentView: View {
                     label: {
                         Text("2. Down Attributed String - default Styler class is used")
                     }).padding(.top, 5.0)
-            
-                Text("P.S. - Down Attributed String uses the standard Styler class by default")
-                    .font(.caption)
-                    .fontWeight(.light)
-                    .multilineTextAlignment(.center)
+                
                 Spacer()
             }
             .navigationBarHidden(true)

--- a/Down-Example/Down-SwiftUI-Example/ContentView.swift
+++ b/Down-Example/Down-SwiftUI-Example/ContentView.swift
@@ -25,12 +25,38 @@ struct ContentView: View {
     
     var body: some View {
         NavigationView {
-            VStack {
+            VStack() {
+                Spacer()
+                Text("Hello")
+                    .font(.title)
+                    .padding(.top, 20.0)
+                    .padding(.bottom, 2.0)
+                
+                Text("This example allows you to get acquainted with the work of Down inside the SwiftUI lifecycle")
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom, 10.0)
+                
+                Spacer()
+                
+                Text("Two options for work are presented:")
+                
                 NavigationLink(
                     destination: DownHTML(markdownString: markdownString),
                     label: {
-                        Text("Down HTML")
-                    })
+                        Text("1. Down HTML")
+                    }).padding(.top, 5.0)
+                
+                NavigationLink(
+                    destination: DownAttributedString(text: markdownString),
+                    label: {
+                        Text("2. Down Attributed String - default Styler class is used")
+                    }).padding(.top, 5.0)
+            
+                Text("P.S. - Down Attributed String uses the standard Styler class by default")
+                    .font(.caption)
+                    .fontWeight(.light)
+                    .multilineTextAlignment(.center)
+                Spacer()
             }
             .navigationBarHidden(true)
         }

--- a/Down-Example/Down-SwiftUI-Example/ContentView.swift
+++ b/Down-Example/Down-SwiftUI-Example/ContentView.swift
@@ -9,14 +9,31 @@
 import SwiftUI
 
 struct ContentView: View {
-    var body: some View {
-        Text("Hello, world!")
-            .padding()
+    
+    @State var markdownString: String
+    
+    init() {
+        if let readMeURL = Bundle.main.url(forResource: nil, withExtension: "md"),
+           let readMeContents = try? String(contentsOf: readMeURL) {
+            markdownString = readMeContents
+        }
+        else {
+            markdownString = ""
+                debugPrint("Could not load readme contents.")
+        }
     }
-}
-
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                NavigationLink(
+                    destination: DownHTML(markdownString: markdownString),
+                    label: {
+                        Text("Down HTML")
+                    })
+            }
+            .navigationBarHidden(true)
+        }
+        
     }
 }

--- a/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
+++ b/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
@@ -26,7 +26,7 @@ class MarkdownObservable: ObservableObject {
         let down = Down(markdownString: text)
         self.isLoading = true
         DispatchQueue(label: "markdownParse").async {
-            let attributedText = try? down.toAttributedString()
+            let attributedText = try? down.toAttributedString(styler: DownStyler())
             
             DispatchQueue.main.async {
                 self.textView.attributedText = attributedText
@@ -47,9 +47,16 @@ struct MarkdownRepresentable: UIViewRepresentable {
     }
     
     func makeUIView(context: Context) -> UITextView {
-        
-        /// Allows you to adjust the alignment of the text
         markdownObject.textView.textAlignment = .left
+        markdownObject.textView.isScrollEnabled = false
+        markdownObject.textView.isUserInteractionEnabled = false
+        markdownObject.textView.showsVerticalScrollIndicator = false
+        markdownObject.textView.showsHorizontalScrollIndicator = false
+        markdownObject.textView.allowsEditingTextAttributes = false
+        markdownObject.textView.backgroundColor = .clear
+        
+        markdownObject.textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        markdownObject.textView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         
         return markdownObject.textView
     }

--- a/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
+++ b/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
@@ -101,5 +101,6 @@ struct DownAttributedString: View {
         }.onReceive(markdownObject.$isLoading, perform: { bool in
             isLoading = bool
         })
+        .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
+++ b/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
@@ -49,10 +49,10 @@ struct MarkdownRepresentable: UIViewRepresentable {
     func makeUIView(context: Context) -> UITextView {
         markdownObject.textView.textAlignment = .left
         markdownObject.textView.isScrollEnabled = false
-        markdownObject.textView.isUserInteractionEnabled = false
+        markdownObject.textView.isUserInteractionEnabled = true
         markdownObject.textView.showsVerticalScrollIndicator = false
         markdownObject.textView.showsHorizontalScrollIndicator = false
-        markdownObject.textView.allowsEditingTextAttributes = false
+        markdownObject.textView.isEditable = false
         markdownObject.textView.backgroundColor = .clear
         
         markdownObject.textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)

--- a/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
+++ b/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
@@ -64,11 +64,9 @@ struct MarkdownRepresentable: UIViewRepresentable {
     func updateUIView(_ uiView: UITextView, context: Context) {
         DispatchQueue.main.async {
             uiView.textColor = colorScheme == .dark ? UIColor.white : UIColor.black
-            DispatchQueue.main.async {
-                dynamicHeight = uiView.sizeThatFits(CGSize(width: uiView.bounds.width,
-                                                           height: CGFloat.greatestFiniteMagnitude))
-                    .height
-            }
+            dynamicHeight = uiView.sizeThatFits(CGSize(width: uiView.bounds.width,
+                                                       height: CGFloat.greatestFiniteMagnitude))
+                .height
         }
     }
 }

--- a/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
+++ b/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
@@ -63,7 +63,11 @@ struct MarkdownRepresentable: UIViewRepresentable {
     
     func updateUIView(_ uiView: UITextView, context: Context) {
         DispatchQueue.main.async {
+            
+            /// Allows you to change the color of the text when switching the device theme.
+            /// I advise you to do it in the future through the configuration when setting up your own Styler class
             uiView.textColor = colorScheme == .dark ? UIColor.white : UIColor.black
+            
             dynamicHeight = uiView.sizeThatFits(CGSize(width: uiView.bounds.width,
                                                        height: CGFloat.greatestFiniteMagnitude))
                 .height

--- a/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
+++ b/Down-Example/Down-SwiftUI-Example/DownAttributedString.swift
@@ -1,0 +1,100 @@
+//
+//  DownAttributedString.swift
+//  Down-SwiftUI-Example
+//
+//  Created by Mikhail Ivanov on 01.06.2021.
+//  Copyright © 2021 Down. All rights reserved.
+//
+
+import SwiftUI
+import Down
+
+class MarkdownObservable: ObservableObject {
+    let textView = UITextView()
+    private let text: String
+    
+    @Published var isLoading: Bool = true
+    
+    init(text: String) {
+        
+        self.text = text
+        
+        loadingDown()
+    }
+    
+    private func loadingDown() {
+        let down = Down(markdownString: text)
+        self.isLoading = true
+        DispatchQueue(label: "markdownParse").async {
+            let attributedText = try? down.toAttributedString()
+            
+            DispatchQueue.main.async {
+                self.textView.attributedText = attributedText
+                
+                self.isLoading = false
+            }
+        }
+    }
+}
+
+struct MarkdownRepresentable: UIViewRepresentable {
+    @Environment(\.colorScheme) var colorScheme
+    @Binding var dynamicHeight: CGFloat
+    @EnvironmentObject var markdownObject: MarkdownObservable
+    
+    init(height: Binding<CGFloat>) {
+        self._dynamicHeight = height
+    }
+    
+    func makeUIView(context: Context) -> UITextView {
+        
+        /// Allows you to adjust the alignment of the text
+        markdownObject.textView.textAlignment = .left
+        
+        return markdownObject.textView
+    }
+    
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        DispatchQueue.main.async {
+            uiView.textColor = colorScheme == .dark ? UIColor.white : UIColor.black
+            DispatchQueue.main.async {
+                dynamicHeight = uiView.sizeThatFits(CGSize(width: uiView.bounds.width,
+                                                           height: CGFloat.greatestFiniteMagnitude))
+                    .height
+            }
+        }
+    }
+}
+
+struct DownAttributedString: View {
+    @ObservedObject private var markdownObject: MarkdownObservable
+    private var markdownString: String
+    @State private var isLoading: Bool = false
+    @State private var height: CGFloat = .zero
+    
+    init(text: String) {
+        self.markdownString = text
+        self.markdownObject = MarkdownObservable(text: text)
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            if isLoading {
+                GeometryReader { geometry in
+                    ProgressView()
+                        .frame(width: geometry.size.width,
+                               height: geometry.size.height,
+                               alignment: .center)
+                }
+            } else {
+                ScrollView {
+                    MarkdownRepresentable(height: $height)
+                        .frame(height: height)
+                        .environmentObject(markdownObject)
+                }
+            }
+        }.onReceive(markdownObject.$isLoading, perform: { bool in
+            isLoading = bool
+        })
+    }
+}

--- a/Down-Example/Down-SwiftUI-Example/DownHTML.swift
+++ b/Down-Example/Down-SwiftUI-Example/DownHTML.swift
@@ -1,0 +1,68 @@
+//
+//  DownHTML.swift
+//  Down-SwiftUI-Example
+//
+//  Created by Mikhail Ivanov on 01.06.2021.
+//  Copyright © 2021 Down. All rights reserved.
+//
+
+import SwiftUI
+import WebKit
+import Down
+
+class MarkdownSize: ObservableObject {
+    @Published var height: CGFloat = 0
+}
+
+struct DownViewSwiftUI: UIViewRepresentable {
+    var markdown: String
+
+    @EnvironmentObject var markdownSize: MarkdownSize
+
+    func makeUIView(context: Context) -> DownView {
+
+        let webView = try? DownView(frame: UIScreen.main.bounds, markdownString: markdown)
+        webView?.navigationDelegate = context.coordinator
+        return webView!
+
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        private var markdownSize: MarkdownSize
+
+        init(_ markdownSize: MarkdownSize) {
+                    self.markdownSize = markdownSize
+                }
+
+        func webView(_ webView: WKWebView,
+                     didFinish navigation: WKNavigation!) {
+            webView.evaluateJavaScript("document.documentElement.scrollHeight") { (height, _) in
+
+                if let height = height as? CGFloat {
+
+                    self.markdownSize.height = height
+                }
+            }
+        }
+    }
+
+    func makeCoordinator() -> DownViewSwiftUI.Coordinator {
+            Coordinator(markdownSize)
+        }
+
+    func updateUIView(_ uiView: DownView, context: Context) {
+
+    }
+
+}
+
+
+struct DownHTML: View {
+    @ObservedObject private var markdownSize = MarkdownSize()
+    
+    @State var markdownString: String
+    var body: some View {
+        DownViewSwiftUI(markdown: markdownString).environmentObject(markdownSize)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Down-Example/Down-SwiftUI-Example/DownHTML.swift
+++ b/Down-Example/Down-SwiftUI-Example/DownHTML.swift
@@ -58,9 +58,10 @@ struct DownViewSwiftUI: UIViewRepresentable {
 
 
 struct DownHTML: View {
+    /// This class has a float variable in it to get data about the length of the resulting markup
     @ObservedObject private var markdownSize = MarkdownSize()
     
-    @State var markdownString: String
+    var markdownString: String
     var body: some View {
         DownViewSwiftUI(markdown: markdownString).environmentObject(markdownSize)
             .navigationBarTitleDisplayMode(.inline)

--- a/Down-Example/Down-SwiftUI-Example/Down_SwiftUI_ExampleApp.swift
+++ b/Down-Example/Down-SwiftUI-Example/Down_SwiftUI_ExampleApp.swift
@@ -1,0 +1,18 @@
+//
+//  Down_SwiftUI_ExampleApp.swift
+//  Down-SwiftUI-Example
+//
+//  Created by Mikhail Ivanov on 01.06.2021.
+//  Copyright © 2021 Down. All rights reserved.
+//
+
+import SwiftUI
+
+@main
+struct Down_SwiftUI_ExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Down-Example/Down-SwiftUI-Example/Info.plist
+++ b/Down-Example/Down-SwiftUI-Example/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Down-Example/Down-SwiftUI-Example/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Down-Example/Down-SwiftUI-Example/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
I suggest adding an example of working with SwiftUI to `Down-Example`, because people are starting to switch to it and the need is growing _(at one time, I myself asked a question about this in the issues :blush:)_

This example demonstrates working with `DownView` and with `Down.toAttributedString`

P.S. - Attribute line down by default uses the standard Styler class, so until _PR #258_ is adopted no images will be displayed