### PR TITLE
Resolve project "Implicit conversion loses integer precision: ..." warnings

### DIFF
--- a/Sources/cmark/blocks.c
+++ b/Sources/cmark/blocks.c
@@ -572,7 +572,7 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
       process = true;
     }
 
-    chunk_len = (eol - buffer);
+    chunk_len = (bufsize_t)(eol - buffer);
     if (process) {
       if (parser->linebuf.size > 0) {
         cmark_strbuf_put(&parser->linebuf, buffer, chunk_len);

--- a/Sources/cmark/buffer.c
+++ b/Sources/cmark/buffer.c
@@ -95,7 +95,7 @@ void cmark_strbuf_set(cmark_strbuf *buf, const unsigned char *data,
 
 void cmark_strbuf_sets(cmark_strbuf *buf, const char *string) {
   cmark_strbuf_set(buf, (const unsigned char *)string,
-                   string ? strlen(string) : 0);
+                   string ? (bufsize_t)strlen(string) : 0);
 }
 
 void cmark_strbuf_putc(cmark_strbuf *buf, int c) {
@@ -116,7 +116,7 @@ void cmark_strbuf_put(cmark_strbuf *buf, const unsigned char *data,
 }
 
 void cmark_strbuf_puts(cmark_strbuf *buf, const char *string) {
-  cmark_strbuf_put(buf, (const unsigned char *)string, strlen(string));
+  cmark_strbuf_put(buf, (const unsigned char *)string, (bufsize_t)strlen(string));
 }
 
 void cmark_strbuf_copy_cstr(char *data, bufsize_t datasize,

--- a/Sources/cmark/commonmark.c
+++ b/Sources/cmark/commonmark.c
@@ -241,7 +241,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       snprintf(listmarker, LISTMARKER_SIZE, "%d%s%s", list_number,
                list_delim == CMARK_PAREN_DELIM ? ")" : ".",
                list_number < 10 ? "  " : " ");
-      marker_width = strlen(listmarker);
+      marker_width = (bufsize_t)strlen(listmarker);
     }
     if (entering) {
       if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {

--- a/Sources/cmark/render.c
+++ b/Sources/cmark/render.c
@@ -20,7 +20,7 @@ static CMARK_INLINE void S_blankline(cmark_renderer *renderer) {
 
 static void S_out(cmark_renderer *renderer, const char *source, bool wrap,
                   cmark_escaping escape) {
-  int length = strlen(source);
+  int length = (int)strlen(source);
   unsigned char nextc;
   int32_t c;
   int i = 0;


### PR DESCRIPTION
### Description
Warnings like
> ⚠️ Implicit conversion loses integer precision: 'long' to 'bufsize_t' (aka 'int')

began showing up in Xcode 13. This PR makes such implicit conversions explicit. Technically the additions in this PR effectively silence these warnings.

### What to test
Nothing really. This just makes the conversion more explicit.