### PR TITLE
Add line and column properties to Node

### DIFF
--- a/Sources/Down/AST/Nodes/Node.swift
+++ b/Sources/Down/AST/Nodes/Node.swift
@@ -112,6 +112,22 @@ public extension CMarkNode {
     var title: String? {
         return String(cString: cmark_node_get_title(self))
     }
+
+    var startLine: Int {
+        return Int(cmark_node_get_start_line(self))
+    }
+
+    var endLine: Int {
+        return Int(cmark_node_get_end_line(self))
+    }
+
+    var startColumn: Int {
+        return Int(cmark_node_get_start_column(self))
+    }
+
+    var endColumn: Int {
+        return Int(cmark_node_get_end_column(self))
+    }
 }
 
 private extension String {


### PR DESCRIPTION
This change provides access to line start/end and column start/end of a Node.
It could be useful for error reporting when validating that a document is of a specific structure.