### PR TITLE
SVGKit Compatibility Hotfix: Change <angled> to "quotes" for imports

### DIFF
--- a/Sources/cmark/cmark.h
+++ b/Sources/cmark/cmark.h
@@ -2,8 +2,8 @@
 #define CMARK_H
 
 #include <stdio.h>
-#include <cmark_export.h>
-#include <cmark_version.h>
+#include "cmark_export.h"
+#include "cmark_version.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
SVGKit and Down blew up for me trying to run. I'm not sure if this is the proper fix, but this does  allow for both to work for now.

<img width="243" alt="Screen Shot 2022-02-08 at 2 03 28 PM" src="https://user-images.githubusercontent.com/10341192/153092853-2f7dbf9e-7e02-45be-90e6-28a9ac8d74e6.png">
<img width="524" alt="Screen Shot 2022-02-08 at 2 03 39 PM" src="https://user-images.githubusercontent.com/10341192/153092854-a17573c1-3d97-4a8e-ad47-7e57550d0910.png">

At any rate, if there's a better solution, let's figure it out.