### PR TITLE
Fixed space between bullet and text to be squashed.

### DIFF
--- a/Sources/Down/AST/Styling/Helpers/ListItemParagraphStyler.swift
+++ b/Sources/Down/AST/Styling/Helpers/ListItemParagraphStyler.swift
@@ -70,7 +70,7 @@ public class ListItemParagraphStyler {
         let firstLineContentIndentation = contentIndentation + prefixSpill
 
         let style = baseStyle
-        style.firstLineHeadIndent = prefixIndentation
+        // style.firstLineHeadIndent = prefixIndentation
         style.tabStops = [tabStop(at: firstLineContentIndentation)]
         style.headIndent = contentIndentation
         return style


### PR DESCRIPTION
This fixes #290